### PR TITLE
Miscellaneous Warning, Documentation, and Convention Fixups

### DIFF
--- a/ShaiRandom.PerformanceTests/Program.cs
+++ b/ShaiRandom.PerformanceTests/Program.cs
@@ -1,5 +1,6 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
+using ShaiRandom.Generators;
 using Troschuetz.Random.Generators;
 namespace ShaiRandom.PerformanceTests
 {

--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using ShaiRandom.Generators;
+using ShaiRandom.Wrappers;
+using Xunit;
 namespace ShaiRandom.UnitTests
 {
     public class BasicTests

--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -18,28 +18,28 @@ namespace ShaiRandom.UnitTests
                 Assert.InRange(fwr.NextExclusiveDouble(), 1.0842021724855044E-19, 0.9999999999999999);
                 Assert.InRange(fwr.NextExclusiveFloat(), 0f, 0.99999994f);
             }
-            fwr.stateD = 1UL;
+            fwr.StateD = 1UL;
             Assert.InRange(fwr.NextExclusiveDouble(), 1.0842021724855044E-19, 0.9999999999999999);
 
-            fwr.stateD = 0UL;
+            fwr.StateD = 0UL;
             Assert.InRange(fwr.NextExclusiveDouble(), 1.0842021724855044E-19, 0.9999999999999999);
 
-            fwr.stateD = 0xFFFFFFFFFFFFFFFFUL;
+            fwr.StateD = 0xFFFFFFFFFFFFFFFFUL;
             Assert.InRange(fwr.NextExclusiveDouble(), 1.0842021724855044E-19, 0.9999999999999999);
 
-            fwr.stateD = 0x8000000000000000UL;
+            fwr.StateD = 0x8000000000000000UL;
             Assert.InRange(fwr.NextExclusiveDouble(), 1.0842021724855044E-19, 0.9999999999999999);
 
-            fwr.stateD = 1UL;
+            fwr.StateD = 1UL;
             Assert.InRange(fwr.NextExclusiveFloat(), 1.0842022E-19f, 0.99999994f);
 
-            fwr.stateD = 0UL;
+            fwr.StateD = 0UL;
             Assert.InRange(fwr.NextExclusiveFloat(), 1.0842022E-19f, 0.99999994f);
 
-            fwr.stateD = 0xFFFFFFFFFFFFFFFFUL;
+            fwr.StateD = 0xFFFFFFFFFFFFFFFFUL;
             Assert.InRange(fwr.NextExclusiveFloat(), 1.0842022E-19f, 0.99999994f);
 
-            fwr.stateD = 0x8000000000000000UL;
+            fwr.StateD = 0x8000000000000000UL;
             Assert.InRange(fwr.NextExclusiveFloat(), 1.0842022E-19f, 0.99999994f);
         }
         [Fact]

--- a/ShaiRandom.UnitTests/Scratch.cs
+++ b/ShaiRandom.UnitTests/Scratch.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ShaiRandom.Generators;
 
 namespace ShaiRandom.UnitTests
 {

--- a/ShaiRandom.UnitTests/Scratch.cs
+++ b/ShaiRandom.UnitTests/Scratch.cs
@@ -31,9 +31,9 @@ namespace ShaiRandom.UnitTests
             {
                 Console.WriteLine(checking + " was outside of bounds");
                 fwr.PreviousULong();
-                Console.WriteLine("previous returned long was {0:X}", fwr.stateD);
-                Console.WriteLine("(int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) : {0:D}", (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | (long)fwr.stateD) >> 52));
-                Console.WriteLine("(127 + 962 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) << 23 : {0:D}", 127 + 962 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | (long)fwr.stateD) >> 52) << 23);
+                Console.WriteLine("previous returned long was {0:X}", fwr.StateD);
+                Console.WriteLine("(int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) : {0:D}", (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | (long)fwr.StateD) >> 52));
+                Console.WriteLine("(127 + 962 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) << 23 : {0:D}", 127 + 962 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | (long)fwr.StateD) >> 52) << 23);
                 //BitConverter.Int32BitsToSingle((127 + 962 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) << 23) | ((int)~bits & 0x007FFFFF));
             }
         }
@@ -62,16 +62,16 @@ namespace ShaiRandom.UnitTests
                 InRange(fwr.NextExclusiveDouble(), 1.0842021724855044E-19, 0.9999999999999999);
                 InRange(fwr.NextExclusiveFloat(), 0f, 0.99999994f);
             }
-            fwr.stateD = 1UL;
+            fwr.StateD = 1UL;
             InRange(fwr.NextExclusiveFloat(), 0f, 0.99999994f);
 
-            fwr.stateD = 0UL;
+            fwr.StateD = 0UL;
             InRange(fwr.NextExclusiveFloat(), 0f, 0.99999994f);
 
-            fwr.stateD = 0xFFFFFFFFFFFFFFFFUL;
+            fwr.StateD = 0xFFFFFFFFFFFFFFFFUL;
             InRange(fwr.NextExclusiveFloat(), 0f, 0.99999994f);
 
-            fwr.stateD = 0x8000000000000000UL;
+            fwr.StateD = 0x8000000000000000UL;
             InRange(fwr.NextExclusiveFloat(), 0f, 0.99999994f);
 
             long bits = -1L;
@@ -80,10 +80,10 @@ namespace ShaiRandom.UnitTests
             Console.WriteLine(BitConverter.Int32BitsToSingle((127 + 962 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) << 23) | ((int)~bits & 0x007FFFFF)));
 
 
-            fwr.stateD = 0xFFFFFFFFFFFFFFFFUL;
+            fwr.StateD = 0xFFFFFFFFFFFFFFFFUL;
             Console.WriteLine(fwr.NextExclusiveFloat());
 
-            fwr.stateD = 0xFFFFFFFFFFFFFFFFUL;
+            fwr.StateD = 0xFFFFFFFFFFFFFFFFUL;
             Console.WriteLine(fwr.NextExclusiveDouble());
 
         }

--- a/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -79,6 +79,7 @@ namespace ShaiRandom.Distributions
             }
         }
 
+        /// <inheritdoc />
         public IEnhancedRandom Generator { get; set; }
 
         #endregion Fields
@@ -182,64 +183,50 @@ namespace ShaiRandom.Distributions
 
         #region IContinuousDistribution Members
 
-        /// <summary>
-        ///   Gets the maximum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Maximum => double.PositiveInfinity;
 
-        /// <summary>
-        ///   Gets the minimum possible value of distributed random numbers.
-        /// </summary>
+
+        /// <inheritdoc />
         public double Minimum => 0.0;
 
-        /// <summary>
-        ///   Gets the mean of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mean is not defined for given distribution with some parameters.
-        /// </exception>
+
+        /// <inheritdoc />
         public double Mean => _lambda;
 
-        /// <summary>
-        ///   Gets the median of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if median is not defined for given distribution with some parameters.
-        /// </exception>
+
+        /// <inheritdoc />
         public double Median => Math.Log(2.0) * _lambda;
 
-        /// <summary>
-        ///   Gets the mode of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mode is not defined for given distribution with some parameters.
-        /// </exception>
+
+        /// <inheritdoc />
         public double[] Mode => new[] { 0.0 };
 
-        /// <summary>
-        ///   Gets the variance of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if variance is not defined for given distribution with some parameters.
-        /// </exception>
+
+        /// <inheritdoc />
         public double Variance => Math.Pow(1.0 / _lambda, -2.0);
 
-        /// <summary>
-        ///   Returns a distributed floating point random number.
-        /// </summary>
-        /// <returns>A distributed double-precision floating point number.</returns>
+
+        /// <inheritdoc />
         public double NextDouble() => Sample(Generator, _lambda);
 
+        /// <inheritdoc />
         public int Steps => 1;
 
+        /// <inheritdoc />
         public int ParameterCount => 1;
 
+        /// <inheritdoc />
         public string ParameterName(int index) => index == 0 ? "Lambda" : "";
+
+        /// <inheritdoc />
         public double ParameterValue(int index)
         {
             if (index == 0) return ParameterLambda;
             throw new NotSupportedException($"The requested index does not exist in this ExponentialDistribution.");
         }
+
+        /// <inheritdoc />
         public void SetParameterValue(int index, double value)
         {
             if (index == 0)

--- a/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
@@ -23,7 +23,9 @@
  * SOFTWARE.
  */
 
-namespace ShaiRandom.Distributions
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.Distributions.Continuous
 {
     using System;
     using ShaiRandom;

--- a/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
@@ -23,7 +23,9 @@
  * SOFTWARE.
  */
 
-namespace ShaiRandom.Distributions
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.Distributions.Continuous
 {
     using System;
     using ShaiRandom;

--- a/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -106,6 +106,7 @@ namespace ShaiRandom.Distributions
             }
         }
 
+        /// <inheritdoc />
         public IEnhancedRandom Generator { get; set; }
 
         #endregion Fields
@@ -222,58 +223,34 @@ namespace ShaiRandom.Distributions
 
         #region IContinuousDistribution Members
 
-        /// <summary>
-        ///   Gets the maximum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Maximum => 1.0;
 
-        /// <summary>
-        ///   Gets the mean of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mean is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Mean => throw new NotSupportedException("I have no idea how to calculate this.");
 
-        /// <summary>
-        ///   Gets the median of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if median is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Median => Math.Pow(1.0 - Math.Pow(2.0, -_b), _a);
 
-        /// <summary>
-        ///   Gets the minimum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Minimum => 0.0;
 
-        /// <summary>
-        ///   Gets the mode of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mode is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double[] Mode => throw new NotSupportedException("I have no idea how to calculate this, or if it is even defined for all valid parameters.");
 
-        /// <summary>
-        ///   Gets the variance of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if variance is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Variance => throw new NotSupportedException("I have no idea how to calculate this, or if it is even defined for all valid parameters.");
 
-        /// <summary>
-        ///   Returns a distributed floating point random number.
-        /// </summary>
-        /// <returns>A distributed double-precision floating point number.</returns>
+        /// <inheritdoc />
         public double NextDouble() => Sample(Generator, _a, _b);
 
+        /// <inheritdoc />
         public int Steps => 1;
 
+        /// <inheritdoc />
         public int ParameterCount => 2;
 
+        /// <inheritdoc />
         public string ParameterName(int index)
         {
             switch (index)
@@ -283,6 +260,8 @@ namespace ShaiRandom.Distributions
                 default: return "";
             }
         }
+
+        /// <inheritdoc />
         public double ParameterValue(int index)
         {
             switch (index)
@@ -292,6 +271,8 @@ namespace ShaiRandom.Distributions
                 default: throw new NotSupportedException($"The requested index does not exist in this KumaraswamyDistribution.");
             }
         }
+
+        /// <inheritdoc />
         public void SetParameterValue(int index, double value)
         {
             switch (index)

--- a/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
@@ -23,7 +23,9 @@
  * SOFTWARE.
  */
 
-namespace ShaiRandom.Distributions
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.Distributions.Continuous
 {
     using System;
     using ShaiRandom;

--- a/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -107,6 +107,7 @@ namespace ShaiRandom.Distributions
             }
         }
 
+        /// <inheritdoc />
         public IEnhancedRandom Generator { get; set; }
 
         #endregion Fields
@@ -222,58 +223,34 @@ namespace ShaiRandom.Distributions
 
         #region IContinuousDistribution Members
 
-        /// <summary>
-        ///   Gets the maximum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Maximum => double.PositiveInfinity;
 
-        /// <summary>
-        ///   Gets the mean of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mean is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Mean => _mu;
 
-        /// <summary>
-        ///   Gets the median of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if median is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Median => _mu;
 
-        /// <summary>
-        ///   Gets the minimum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Minimum => double.NegativeInfinity;
 
-        /// <summary>
-        ///   Gets the mode of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mode is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double[] Mode => new[] { _mu };
 
-        /// <summary>
-        ///   Gets the variance of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if variance is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Variance => _sigma * _sigma;
 
-        /// <summary>
-        ///   Returns a distributed floating point random number.
-        /// </summary>
-        /// <returns>A distributed double-precision floating point number.</returns>
+        /// <inheritdoc />
         public double NextDouble() => Sample(Generator, _mu, _sigma);
 
+        /// <inheritdoc />
         public int Steps => 1;
 
+        /// <inheritdoc />
         public int ParameterCount => 2;
 
+        /// <inheritdoc />
         public string ParameterName(int index)
         {
             switch (index)
@@ -283,6 +260,8 @@ namespace ShaiRandom.Distributions
                 default: return "";
             }
         }
+
+        /// <inheritdoc />
         public double ParameterValue(int index)
         {
             switch (index)
@@ -292,6 +271,8 @@ namespace ShaiRandom.Distributions
                 default: throw new NotSupportedException($"The requested index does not exist in this NormalDistribution.");
             }
         }
+
+        /// <inheritdoc />
         public void SetParameterValue(int index, double value)
         {
             switch (index)

--- a/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
@@ -23,7 +23,9 @@
  * SOFTWARE.
  */
 
-namespace ShaiRandom.Distributions
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.Distributions.Continuous
 {
     using System;
     using ShaiRandom;

--- a/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -34,7 +34,7 @@ namespace ShaiRandom.Distributions
     /// <remarks>
     ///   <para>
     ///     The implementation of the <see cref="TriangularDistribution"/> type bases upon
-    ///     information presented on 
+    ///     information presented on
     ///     <a href="http://en.wikipedia.org/wiki/Triangular_distribution">Wikipedia - Triangular
     ///     distribution</a> and the implementation in the
     ///     <a href="http://www.boost.org/libs/random/index.html">Boost Random Number Library</a>.
@@ -140,6 +140,7 @@ namespace ShaiRandom.Distributions
             }
         }
 
+        /// <inheritdoc />
         public IEnhancedRandom Generator { get; set; }
 
         #endregion Fields
@@ -265,25 +266,13 @@ namespace ShaiRandom.Distributions
 
         #region IContinuousDistribution Members
 
-        /// <summary>
-        ///   Gets the maximum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Maximum => _beta;
 
-        /// <summary>
-        ///   Gets the mean of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mean is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Mean => (_alpha + _beta + _gamma) / 3.0;
 
-        /// <summary>
-        ///   Gets the median of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if median is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Median
         {
             get
@@ -296,38 +285,26 @@ namespace ShaiRandom.Distributions
             }
         }
 
-        /// <summary>
-        ///   Gets the minimum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Minimum => _alpha;
 
-        /// <summary>
-        ///   Gets the mode of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mode is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double[] Mode => new[] { _gamma };
 
-        /// <summary>
-        ///   Gets the variance of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if variance is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Variance => ((_alpha * _alpha) + (_beta * _beta) + (_gamma * _gamma) - _alpha * _beta -
-                        (_alpha + _beta) * _gamma) / 18.0;
+                                   (_alpha + _beta) * _gamma) / 18.0;
 
-        /// <summary>
-        ///   Returns a distributed floating point random number.
-        /// </summary>
-        /// <returns>A distributed double-precision floating point number.</returns>
+        /// <inheritdoc />
         public double NextDouble() => Sample(Generator, _alpha, _beta, _gamma);
 
+        /// <inheritdoc />
         public int Steps => 1;
 
+        /// <inheritdoc />
         public int ParameterCount => 3;
 
+        /// <inheritdoc />
         public string ParameterName(int index)
         {
             switch (index)
@@ -338,6 +315,8 @@ namespace ShaiRandom.Distributions
                 default: return "";
             }
         }
+
+        /// <inheritdoc />
         public double ParameterValue(int index)
         {
             switch (index)
@@ -348,6 +327,8 @@ namespace ShaiRandom.Distributions
                 default: throw new NotSupportedException($"The requested index does not exist in this TriangularDistribution.");
             }
         }
+
+        /// <inheritdoc />
         public void SetParameterValue(int index, double value)
         {
             switch (index)

--- a/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -78,7 +78,7 @@ namespace ShaiRandom.Distributions
         ///   <paramref name="value"/> is less than or equal to zero.
         /// </exception>
         /// <remarks>
-        ///   Calls <see cref="IsValidParam"/> to determine whether a value is valid and therefore assignable.
+        ///   Calls <see cref="IsValidAlpha"/> to determine whether a value is valid and therefore assignable.
         /// </remarks>
         public double ParameterAlpha
         {
@@ -98,7 +98,7 @@ namespace ShaiRandom.Distributions
         ///   <paramref name="value"/> is less than or equal to zero.
         /// </exception>
         /// <remarks>
-        ///   Calls <see cref="IsValidParam"/> to determine whether a value is valid and therefore assignable.
+        ///   Calls <see cref="IsValidBeta"/> to determine whether a value is valid and therefore assignable.
         /// </remarks>
         public int ParameterBeta
         {
@@ -110,6 +110,7 @@ namespace ShaiRandom.Distributions
             }
         }
 
+        /// <inheritdoc />
         public IEnhancedRandom Generator { get; set; }
 
         #endregion Fields
@@ -120,7 +121,7 @@ namespace ShaiRandom.Distributions
         ///   Initializes a new instance of the <see cref="BinomialDistribution"/> class, using a
         ///   <see cref="LaserRandom"/> as underlying random number generator.
         /// </summary>
-        public BinomialDistribution() : this(new LaserRandom(), DefaultAlpha, DefaultBeta)
+        public BinomialDistribution() : this(new LaserRandom())
         {
         }
 
@@ -131,7 +132,7 @@ namespace ShaiRandom.Distributions
         /// <param name="seed">
         ///   An unsigned long used to calculate a starting value for the pseudo-random number sequence.
         /// </param>
-        public BinomialDistribution(ulong seed) : this(new LaserRandom(seed), DefaultAlpha, DefaultBeta)
+        public BinomialDistribution(ulong seed) : this(new LaserRandom(seed))
         {
         }
 
@@ -146,17 +147,7 @@ namespace ShaiRandom.Distributions
         /// <param name="seedB">
         ///   An unsigned long used to calculate a starting value for the pseudo-random number sequence. Usually an odd number; the last bit isn't used.
         /// </param>
-        public BinomialDistribution(ulong seedA, ulong seedB) : this(new LaserRandom(seedA, seedB), DefaultAlpha, DefaultBeta)
-        {
-        }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="BinomialDistribution"/> class, using
-        ///   the specified <see cref="IEnhancedRandom"/> as underlying random number generator.
-        /// </summary>
-        /// <param name="generator">An <see cref="IEnhancedRandom"/> object.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="generator"/> is <see langword="null"/>.</exception>
-        public BinomialDistribution(IEnhancedRandom generator) : this(generator, DefaultAlpha, DefaultBeta)
+        public BinomialDistribution(ulong seedA, ulong seedB) : this(new LaserRandom(seedA, seedB))
         {
         }
 
@@ -166,6 +157,9 @@ namespace ShaiRandom.Distributions
         /// </summary>
         /// <param name="alpha">
         ///   The parameter alpha which is used for generation of Binomial distributed random numbers.
+        /// </param>
+        /// <param name="beta">
+        ///   The parameter beta which is used for generation of Binomial distributed random numbers.
         /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="alpha"/> is less than or equal to zero.
@@ -184,8 +178,11 @@ namespace ShaiRandom.Distributions
         /// <param name="alpha">
         ///   The parameter alpha which is used for generation of Binomial distributed random numbers.
         /// </param>
+        /// <param name="beta">
+        ///   The parameter beta which is used for generation of Binomial distributed random numbers.
+        /// </param>
         /// <exception cref="ArgumentOutOfRangeException">
-        ///   <paramref name="alpha"/> is less than or equal to zero.
+        ///   <paramref name="alpha"/> or <paramref name="beta"/> is less than or equal to zero.
         /// </exception>
         public BinomialDistribution(ulong seed, double alpha, int beta) : this(new LaserRandom(seed), alpha, beta)
         {
@@ -199,11 +196,14 @@ namespace ShaiRandom.Distributions
         /// <param name="alpha">
         ///   The parameter alpha which is used for generation of Binomial distributed random numbers.
         /// </param>
+        /// <param name="beta">
+        /// The parameter beta which is used for generation of Binomial distributed random numbers.
+        /// </param>
         /// <exception cref="ArgumentNullException"><paramref name="generator"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         ///   <paramref name="alpha"/> is less than or equal to zero.
         /// </exception>
-        public BinomialDistribution(IEnhancedRandom generator, double alpha, int beta)
+        public BinomialDistribution(IEnhancedRandom generator, double alpha = DefaultAlpha, int beta = DefaultBeta)
         {
             Generator = generator;
             ParameterAlpha = alpha;
@@ -214,70 +214,48 @@ namespace ShaiRandom.Distributions
 
         #region IContinuousDistribution Members
 
-        /// <summary>
-        ///   Gets the maximum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Maximum => _beta;
 
-        /// <summary>
-        ///   Gets the minimum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Minimum => 0.0;
 
-        /// <summary>
-        ///   Gets the mean of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mean is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Mean => _alpha * _beta;
 
-        /// <summary>
-        ///   Gets the median of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if median is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Median => throw new NotSupportedException("Median is not supported by BinomialDistribution.");
 
-        /// <summary>
-        ///   Gets the mode of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mode is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double[] Mode => new[] { Math.Floor(_alpha * (_beta + 1.0)) };
 
-        /// <summary>
-        ///   Gets the variance of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if variance is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Variance => _alpha * (1.0 - _alpha) * _beta;
 
-        /// <summary>
-        ///   Returns a distributed floating point random number.
-        /// </summary>
-        /// <returns>A distributed double-precision floating point number.</returns>
+        /// <inheritdoc />
         public double NextDouble() => Sample(Generator, _alpha, _beta);
-        /// <summary>
-        ///   Returns a distributed integer random number.
-        /// </summary>
-        /// <returns>A distributed integer number.</returns>
+
+        /// <inheritdoc />
         public int NextInt() => Sample(Generator, _alpha, _beta);
 
+        /// <inheritdoc />
         public int Steps => _beta;
 
+        /// <inheritdoc />
         public int ParameterCount => 2;
 
+        /// <inheritdoc />
         public string ParameterName(int index) => index == 0 ? "Alpha" : index == 1 ? "Beta" : "";
+
+        /// <inheritdoc />
         public double ParameterValue(int index)
         {
             if (index == 0) return ParameterAlpha;
             if (index == 1) return ParameterBeta;
             throw new NotSupportedException($"The requested index does not exist in this BinomialDistribution.");
         }
+
+        /// <inheritdoc />
         public void SetParameterValue(int index, double value)
         {
             if (index == 0)

--- a/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
@@ -23,7 +23,9 @@
  * SOFTWARE.
  */
 
-namespace ShaiRandom.Distributions
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.Distributions.Discrete
 {
     using System;
     using ShaiRandom;

--- a/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -79,6 +79,7 @@ namespace ShaiRandom.Distributions
             }
         }
 
+        /// <inheritdoc />
         public IEnhancedRandom Generator { get; set; }
 
         #endregion Fields
@@ -182,69 +183,47 @@ namespace ShaiRandom.Distributions
 
         #region IContinuousDistribution Members
 
-        /// <summary>
-        ///   Gets the maximum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Maximum => double.PositiveInfinity;
 
-        /// <summary>
-        ///   Gets the minimum possible value of distributed random numbers.
-        /// </summary>
+        /// <inheritdoc />
         public double Minimum => 0.0;
 
-        /// <summary>
-        ///   Gets the mean of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mean is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Mean => _lambda;
 
-        /// <summary>
-        ///   Gets the median of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if median is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Median => Math.Floor(_lambda + 0.333333333333333333 - 0.02 / _lambda);
 
-        /// <summary>
-        ///   Gets the mode of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if mode is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double[] Mode => new[] { Math.Ceiling(_lambda) - 1, Math.Floor(_lambda) };
 
-        /// <summary>
-        ///   Gets the variance of distributed random numbers.
-        /// </summary>
-        /// <exception cref="NotSupportedException">
-        ///   Thrown if variance is not defined for given distribution with some parameters.
-        /// </exception>
+        /// <inheritdoc />
         public double Variance => _lambda;
 
-        /// <summary>
-        ///   Returns a distributed floating point random number.
-        /// </summary>
-        /// <returns>A distributed double-precision floating point number.</returns>
+        /// <inheritdoc />
         public double NextDouble() => Sample(Generator, _lambda);
-        /// <summary>
-        ///   Returns a distributed integer random number.
-        /// </summary>
-        /// <returns>A distributed integer number.</returns>
+
+        /// <inheritdoc />
         public int NextInt() => Sample(Generator, _lambda);
 
+        /// <inheritdoc />
         public int Steps => 1;
 
+        /// <inheritdoc />
         public int ParameterCount => 1;
 
+        /// <inheritdoc />
         public string ParameterName(int index) => index == 0 ? "Lambda" : "";
+
+        /// <inheritdoc />
         public double ParameterValue(int index)
         {
             if (index == 0) return ParameterLambda;
             throw new NotSupportedException($"The requested index does not exist in this PoissonDistribution.");
         }
+
+        /// <inheritdoc />
         public void SetParameterValue(int index, double value)
         {
             if (index == 0)

--- a/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
@@ -23,7 +23,9 @@
  * SOFTWARE.
  */
 
-namespace ShaiRandom.Distributions
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.Distributions.Discrete
 {
     using System;
     using ShaiRandom;

--- a/ShaiRandom/EnhancedRandom.cs
+++ b/ShaiRandom/EnhancedRandom.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using ShaiRandom.Generators;
+using ShaiRandom.Wrappers;
 
 namespace ShaiRandom
 {

--- a/ShaiRandom/EnhancedRandom.cs
+++ b/ShaiRandom/EnhancedRandom.cs
@@ -1765,7 +1765,7 @@ namespace ShaiRandom
                 (items[i], items[ii]) = (items[ii], items[i]);
             }
         }
-        
+
         /// <summary>
         /// Shuffles a section of the given IList in-place pseudo-randomly, using this to generate
         /// {@code length - 1} random numbers and using the Fisher-Yates (also called Knuth) shuffle algorithm.

--- a/ShaiRandom/EnhancedRandom.cs
+++ b/ShaiRandom/EnhancedRandom.cs
@@ -363,7 +363,7 @@ namespace ShaiRandom
         /// </summary>
         /// <remarks>
         /// If outerBound is less than or equal to innerBound,
-        /// this always returns innerBound. 
+        /// this always returns innerBound.
         /// </remarks>
         /// <seealso cref="NextUInt(uint)"> Here's a note about the bias present in the bounded generation.</seealso>
         /// <param name="innerBound">the inclusive inner bound; may be any int, allowing negative</param>
@@ -898,7 +898,7 @@ namespace ShaiRandom
         private static readonly double DOUBLE_ADJUST = Math.Pow(2.0, -53.0);
         /// <summary>
         /// Used by <see cref="MakeSeed"/> to produce mid-low quality random numbers as a starting seed, as a "don't care" option for seeding.
-        /// </summary>        
+        /// </summary>
         protected static readonly Random SeedingRandom = new Random();
 
         /// <summary>
@@ -934,44 +934,22 @@ namespace ShaiRandom
             SetWith(other);
         }
 
-        /// <summary>
-        /// Sets the seed of this random number generator using a single ulong seed.
-        /// </summary>
-        /// <remarks>
-        /// This does not necessarily assign the state variable(s) of the implementation with the exact contents of seed,
-        /// so <see cref="SelectState(int)"/> should not be expected to return seed after this, though it may.
-        /// </remarks>
-        /// <param name="seed">May be any ulong; if the seed would give an invalid state, the generator is expected to correct that state.</param>
+        /// <inheritdoc />
         public abstract void Seed(ulong seed);
-        /// <summary>
-        /// Gets the number of possible state variables that can be selected with
-        /// <see cref="SelectState(int)"/> or <see cref="SetSelectedState(int, ulong)"/>,
-        /// even if those methods are not publicly accessible. An implementation that has only
-        /// one ulong or uint state, like <see cref="DistinctRandom"/>, should produce 1.
-        /// An implementation that has two uint or ulong states should produce 2, etc.
-        /// This is always a non-negative number; though discouraged, it is allowed to be 0 for
-        /// generators that attempt to conceal their state.
-        /// </summary>
+
+        /// <inheritdoc />
         public abstract int StateCount { get; }
 
-        /// <summary>
-        /// This should be true if the implementation supports <see cref="SelectState(int)"/>, or false if that method is unsupported.
-        /// </summary>
+        /// <inheritdoc />
         public abstract bool SupportsReadAccess { get; }
 
-        /// <summary>
-        /// This should be true if the implementation supports <see cref="SetSelectedState(int, ulong)"/>, or false if that method is unsupported.
-        /// </summary>
+        /// <inheritdoc />
         public abstract bool SupportsWriteAccess { get; }
 
-        /// <summary>
-        /// This should be true if the implementation supports <see cref="Skip(ulong)"/>, or false if that method is unsupported.
-        /// </summary>
+        /// <inheritdoc />
         public abstract bool SupportsSkip { get; }
 
-        /// <summary>
-        /// This should be true if the implementation supports <see cref="PreviousULong"/>, or false if that method is unsupported.
-        /// </summary>
+        /// <inheritdoc />
         public abstract bool SupportsPrevious { get; }
 
         /// <summary>
@@ -998,18 +976,10 @@ namespace ShaiRandom
             return false;
         }
 
-        /// <summary>
-        /// Produces a string that encodes the type and full state of this generator.
-        /// </summary>
-        /// <returns>An encoded string that stores the type and full state of this generator.</returns>
+        /// <inheritdoc />
         public abstract string StringSerialize();
 
-        /// <summary>
-        /// Given a string produced by <see cref="StringSerialize"/>, if the specified type is compatible,
-        /// then this method sets the state of this IEnhancedRandom to the specified stored state.
-        /// </summary>
-        /// <param name="data">A string produced by StringSerialize.</param>
-        /// <returns>This IEnhancedRandom, after modifications.</returns>
+        /// <inheritdoc />
         public abstract IEnhancedRandom StringDeserialize(string data);
 
         /// <summary>
@@ -1029,46 +999,19 @@ namespace ShaiRandom
             return TAGS[data.Substring(1, 4)].Copy().StringDeserialize(data);
         }
 
-        /// <summary>
-        /// Gets a selected state value from this AbstractRandom, by index.
-        /// </summary>
-        /// <remarks>
-        /// The number of possible selections is up to the implementing class, and is accessible via <see cref="StateCount"/>, but negative values for selection are typically not tolerated.
-        /// This should return the exact value of the selected state, assuming it is implemented. The default implementation throws an NotSupportedException, and implementors only have to
-        /// allow reading the state if they choose to implement this differently. If this method is intended to be used, <see cref="StateCount"/> must also be implemented.
-        /// </remarks>
-        /// <param name="selection">The index of the state to retrieve.</param>
-        /// <returns>The value of the state corresponding to selection</returns>
-        /// <exception cref="NotSupportedException">If the generator does not allow reading its state.</exception>
+        /// <inheritdoc />
         public virtual ulong SelectState(int selection)
         {
             throw new NotSupportedException("SelectState() not supported.");
         }
 
-        /// <summary>
-        /// Sets a selected state value to the given ulong value.
-        /// </summary>
-        /// <remarks>
-        /// The number of possible selections is up to the implementing class, but selection should be at least 0 and less than <see cref="StateCount"/>.
-        /// Implementors are permitted to change value if it is not valid, but they should not alter it if it is valid.
-        /// The public implementation calls <see cref="Seed(ulong)"/> with value, which doesn't need changing if the generator has one state that is set verbatim by Seed().
-        /// Otherwise, this method should be implemented when <see cref="SelectState(int)"/> is and the state is allowed to be set by users.
-        /// Having accurate ways to get and set the full state of a random number generator makes it much easier to serialize and deserialize that class.
-        /// </remarks>
-        /// <param name="selection">The index of the state to set.</param>
-        /// <param name="value">The value to try to use for the selected state.</param>
+        /// <inheritdoc />
         public virtual void SetSelectedState(int selection, ulong value)
         {
             Seed(value);
         }
 
-        /// <summary>
-        /// Sets every state variable to the given state.
-        /// </summary>
-        /// <remarks>
-        /// If <see cref="StateCount"/> is 1, then this should set the whole state to the given value using <see cref="SetSelectedState(int, ulong)"/>.
-        /// If StateCount is more than 1, then all states will be set in the same way (using SetSelectedState(), all to state).</remarks>
-        /// <param name="state">The ulong variable to use for every state variable.</param>
+        /// <inheritdoc />
         public virtual void SetState(ulong state)
         {
             for (int i = StateCount - 1; i >= 0; i--)
@@ -1076,18 +1019,8 @@ namespace ShaiRandom
                 SetSelectedState(i, state);
             }
         }
-        
-        /// <summary>
-        /// Sets each state variable to either stateA or stateB, alternating.
-        /// </summary>
-        /// <remarks>
-        /// This uses <see cref="SetSelectedState(int, ulong)"/> to set the values.
-        /// If there is one state variable (<see cref="StateCount"/> is 1), then this only sets that state variable to stateA.
-        /// If there are two state variables, the first is set to stateA, and the second to stateB.
-        ///  there are more, it reuses stateA, then stateB, then stateA, and so on until all variables are set.
-        /// </remarks>
-        /// <param name="stateA">The ulong value to use for states at index 0, 2, 4, 6...</param>
-        /// <param name="stateB">The ulong value to use for states at index 1, 3, 5, 7...</param>
+
+        /// <inheritdoc />
         public virtual void SetState(ulong stateA, ulong stateB)
         {
             int c = StateCount;
@@ -1101,21 +1034,7 @@ namespace ShaiRandom
             }
         }
 
-        /// <summary>
-        /// Sets each state variable to stateA, stateB, or stateC, alternating.
-        /// </summary>
-        /// <remarks>
-        /// This uses <see cref="SetSelectedState(int, ulong)"/> to set the values.
-        /// If there is one state variable (<see cref="StateCount"/> is 1), then this only
-        /// sets that state variable to stateA. If there are two state variables, the first
-        /// is set to stateA, and the second to stateB. With three state variables, the
-        /// first is set to stateA, the second to stateB, and the third to stateC. If there
-        /// are more, it reuses stateA, then stateB, then stateC, then stateA, and so on
-        /// until all variables are set.
-        /// </remarks>
-        /// <param name="stateA">The ulong value to use for states at index 0, 3, 6, 9...</param>
-        /// <param name="stateB">The ulong value to use for states at index 1, 4, 7, 10...</param>
-        /// <param name="stateC">The ulong value to use for states at index 2, 5, 8, 11...</param>
+        /// <inheritdoc />
         public virtual void SetState(ulong stateA, ulong stateB, ulong stateC)
         {
             int c = StateCount;
@@ -1133,24 +1052,7 @@ namespace ShaiRandom
             }
         }
 
-        /// <summary>
-        /// Sets each state variable to stateA, stateB, stateC, or stateD, alternating.
-        /// </summary>
-        /// <remarks>
-        /// This uses <see cref="SetSelectedState(int, ulong)"/> to
-        /// set the values. If there is one state variable (<see cref="StateCount"/> is 1),
-        /// then this only sets that state variable to stateA. If there are two state
-        /// variables, the first is set to stateA, and the second to stateB. With three
-        /// state variables, the first is set to stateA, the second to stateB, and the third
-        /// to stateC. With four state variables, the first is set to stateA, the second to
-        /// stateB, the third to stateC, and the fourth to stateD. If there are more, it
-        /// reuses stateA, then stateB, then stateC, then stateD, then stateA, and so on
-        /// until all variables are set.
-        /// </remarks>
-        /// <param name="stateA">the ulong value to use for states at index 0, 4, 8, 12...</param>
-        /// <param name="stateB">the ulong value to use for states at index 1, 5, 9, 13...</param>
-        /// <param name="stateC">the ulong value to use for states at index 2, 6, 10, 14...</param>
-        /// <param name="stateD">the ulong value to use for states at index 3, 7, 11, 15...</param>
+        /// <inheritdoc />
         public virtual void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
             int c = StateCount;
@@ -1172,16 +1074,7 @@ namespace ShaiRandom
             }
         }
 
-        /// <summary>
-        /// Sets all state variables to cycling values chosen from states.'
-        /// </summary>
-        /// <remarks>
-        /// If states is empty, then this does nothing, and leaves the current generator unchanged.
-        /// This works for generators with any <see cref="StateCount"/>, but may allocate an array if states is
-        /// used as params (you can pass an existing array without needing to allocate). This
-        /// uses <see cref="SetSelectedState(int, ulong)"/> to change the states.
-        /// </remarks>
-        /// <param name="states">An array or params array of ulong values to use as states.</param>
+        /// <inheritdoc />
         public virtual void SetState(params ulong[] states)
         {
             int c = StateCount, sl = states.Length;
@@ -1194,21 +1087,10 @@ namespace ShaiRandom
             }
         }
 
-        /// <summary>
-        /// Returns the next pseudorandom, uniformly distributed ulong
-        /// value from this random number generator's sequence, in the full range of all possible ulong values.
-        /// <remarks>
-        /// The general contract of NextULong is that one ulong value is
-        /// pseudorandomly generated and returned.
-        /// </remarks>
-        /// <returns>The next pseudorandom, uniformly distributed ulong value from this random number generator's sequence.</returns>
+        /// <inheritdoc />
         public abstract ulong NextULong();
 
-        /// <summary>
-        /// Returns the next pseudorandom, uniformly distributed long
-        /// value from this random number generator's sequence, in the full range of all possible long values (positive and negative).
-        /// </summary>
-        /// <returns>The next pseudorandom, uniformly distributed long value from this random number generator's sequence.</returns>
+        /// <inheritdoc />
         public long NextLong()
         {
             unchecked
@@ -1217,69 +1099,19 @@ namespace ShaiRandom
             }
         }
 
-        /// <summary>
-        /// Returns a pseudorandom, uniformly distributed long value
-        /// between 0 (inclusive) and the specified value (exclusive), drawn from
-        /// this random number generator's sequence.
-        /// </summary>
-        /// <remarks>
-        /// The general contract of
-        /// nextULong is that one ulong value in the specified range
-        /// is pseudorandomly generated and returned.  All possible
-        /// long values within the bound are produced with (approximately) equal
-        /// probability, though there is a small amount of bias depending on the bound.
-        /// <br/>
-        /// Note that this advances the state by the same amount as a single call to
-        /// <see cref="NextULong()"/>, which allows methods like <see cref="Skip(ulong)"/> to function
-        /// correctly, but introduces some bias when bound is very large. This will
-        /// also advance the state if bound is 0 or negative, so usage with a variable
-        /// bound will advance the state reliably.
-        /// <br/>
-        /// This method has some bias, particularly on larger bounds. Actually measuring
-        /// bias with bounds in the trillions or greater is challenging but not impossible, so
-        /// don't use this for a real-money gambling purpose. The bias isn't especially
-        /// significant, though.
-        /// </remarks>
-        /// <seealso cref="NextUInt(uint)"> Here's a note about the bias present in the bounded generation.</seealso>
-        /// <param name="bound">the upper bound (exclusive). If negative or 0, this always returns 0.</param>
-        /// <returns>the next pseudorandom, uniformly distributed long value between zero (inclusive) and bound (exclusive) from this random number generator's sequence</returns>
+        /// <inheritdoc />
         public ulong NextULong(ulong bound)
         {
             return NextULong(0UL, bound);
         }
 
-        /// <summary>
-        /// Returns a pseudorandom, uniformly distributed long value between an
-        /// inner bound of 0 (inclusive) and the specified outerBound (exclusive).
-        /// </summary>
-        /// <remarks>
-        /// This is meant for cases where the outer bound may be negative, especially if
-        /// the bound is unknown or may be user-specified. A negative outer bound is used
-        /// as the lower bound; a positive outer bound is used as the upper bound. An outer
-        /// bound of -1, 0, or 1 will always return 0, keeping the bound exclusive (except
-        /// for outer bound 0).
-        /// <br/>Note that this advances the state by the same amount as a single call to
-        /// <see cref="NextULong()"/>, which allows methods like <see cref="Skip(ulong)"/> to function
-        /// correctly, but introduces some bias when bound is very large.
-        /// </remarks>
-        /// <seealso cref="NextUInt(uint)"> Here's a note about the bias present in the bounded generation.</seealso>
-        /// <param name="outerBound">the outer exclusive bound; may be any long value, allowing negative</param>
-        /// <returns>a pseudorandom long between 0 (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public long NextLong(long outerBound)
         {
             return NextLong(0L, outerBound);
         }
 
-        /// <summary>
-        /// Returns a pseudorandom, uniformly distributed long value between the
-        /// specified innerBound (inclusive) and the specified outerBound
-        /// (exclusive). If outerBound is less than or equal to innerBound,
-        /// this always returns innerBound.
-        /// </summary>
-        /// <seealso cref="NextUInt(uint)"> Here's a note about the bias present in the bounded generation.</seealso>
-        /// <param name="inner">the inclusive inner bound; may be any long, allowing negative</param>
-        /// <param name="outer">the exclusive outer bound; must be greater than innerBound (otherwise this returns innerBound)</param>
-        /// <returns>a pseudorandom long between innerBound (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public ulong NextULong(ulong inner, ulong outer)
         {
             ulong rand = NextULong();
@@ -1292,15 +1124,7 @@ namespace ShaiRandom
             return inner + (randHigh * boundLow >> 32) + (randLow * boundHigh >> 32) + randHigh * boundHigh;
         }
 
-        /// <summary>
-        /// Returns a pseudorandom, uniformly distributed long value between the
-        /// specified innerBound (inclusive) and the specified outerBound
-        /// (exclusive). This is meant for cases where either bound may be negative,
-        /// especially if the bounds are unknown or may be user-specified.
-        /// <seealso cref="NextUInt(uint)"> Here's a note about the bias present in the bounded generation.</seealso>
-        /// <param name="inner">the inclusive inner bound; may be any long, allowing negative</param>
-        /// <param name="outer">the exclusive outer bound; may be any long, allowing negative</param>
-        /// <returns>a pseudorandom long between innerBound (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public long NextLong(long inner, long outer)
         {
             ulong rand = NextULong();
@@ -1338,17 +1162,13 @@ namespace ShaiRandom
         /// </remarks>
         /// <param name="bits">The amount of random bits to request, from 1 to 32.</param>
         /// <returns>The next pseudorandom value from this random number generator's sequence.</returns>
-        /// 
+        ///
         public uint NextBits(int bits)
         {
             return (uint)(NextULong() >> 64 - bits);
         }
 
-        /// <summary>
-        /// Generates random bytes and places them into a user-supplied
-        /// byte array.  The number of random bytes produced is equal to
-        /// the length of the byte array.
-        /// <param name="bytes">the byte array to fill with random bytes</param>
+        /// <inheritdoc />
         public void NextBytes(byte[] bytes)
         {
             int bl = bytes.Length;
@@ -1362,52 +1182,19 @@ namespace ShaiRandom
             }
         }
 
-        /// <summary>
-        /// Returns the next pseudorandom, uniformly distributed int
-        /// value from this random number generator's sequence. The general
-        /// contract of nextInt is that one int value is
-        /// pseudorandomly generated and returned. All 2<sup>32</sup> possible
-        /// int values are produced with (approximately) equal probability.
-        /// </summary>
-        /// <returns>The next pseudorandom, uniformly distributed int value from this random number generator's sequence.</returns>
+        /// <inheritdoc />
         public int NextInt()
         {
             return (int)NextULong();
         }
 
-        /// <summary>
-        /// Gets a random uint by using the low 32 bits of NextULong(); this can return any uint.
-        /// </summary>
-        /// <returns>Any random uint.</returns>
+        /// <inheritdoc />
         public uint NextUInt()
         {
             return (uint)NextULong();
         }
 
-        /// <summary>
-        /// Returns a pseudorandom, uniformly distributed int value
-        /// between 0 (inclusive) and the specified value (exclusive), drawn from
-        /// this random number generator's sequence.
-        /// </summary>
-        /// <remarks>The general contract of
-        /// nextInt is that one int value in the specified range
-        /// is pseudorandomly generated and returned.  All bound possible
-        /// int values are produced with (approximately) equal
-        /// probability.
-        /// <br/>
-        /// It should be mentioned that the technique this uses has some bias, depending
-        /// on bound, but it typically isn't measurable without specifically looking
-        /// for it. Using the method this does allows this method to always advance the state
-        /// by one step, instead of a varying and unpredictable amount with the more typical
-        /// ways of rejection-sampling random numbers and only using numbers that can produce
-        /// an int within the bound without bias.
-        /// See <a href="https://www.pcg-random.org/posts/bounded-rands.html">M.E. O'Neill's
-        /// blog about random numbers</a> for discussion of alternative, unbiased methods.
-        /// </remarks>
-        /// <param name="bound">the upper bound (exclusive). If negative or 0, this always returns 0.</param>
-        /// <returns>the next pseudorandom, uniformly distributed int</returns>
-        /// value between zero (inclusive) and bound (exclusive)
-        /// from this random number generator's sequence
+        /// <inheritdoc />
         public uint NextUInt(uint bound)
         {
             return (uint)(bound * (NextULong() & 0xFFFFFFFFUL) >> 32);
@@ -1465,185 +1252,80 @@ namespace ShaiRandom
             return (int)NextLong(innerBound, outerBound);
         }
 
-        /// <summary>
-        /// Returns the next pseudorandom, uniformly distributed
-        /// bool value from this random number generator's
-        /// sequence. The general contract of NextBool is that one
-        /// bool value is pseudorandomly generated and returned.  The
-        /// values true and false are produced with
-        /// (approximately) equal probability.
-        /// 
-        /// The default implementation is equivalent to a sign check on <see cref="NextLong()"/>
-        /// returning true if the generated long is negative. This is typically the safest
-        /// way to implement this method; many types of generators have less statistical
-        /// quality on their lowest bit, so just returning based on the lowest bit isn't
-        /// always a good idea.
-        /// <returns>the next pseudorandom, uniformly distributed</returns>
-        /// bool value from this random number generator's
-        /// sequence
+        /// <inheritdoc />
         public virtual bool NextBool()
         {
             return (NextULong() & 0x8000000000000000UL) == 0x8000000000000000UL;
         }
 
-        /// <summary>
-        /// Returns the next pseudorandom, uniformly distributed float
-        /// value between 0.0 (inclusive) and 1.0 (exclusive)
-        /// from this random number generator's sequence.
-        /// </summary>
-        /// <remarks>The general contract of NextFloat is that one
-        /// float value, chosen (approximately) uniformly from the
-        /// range 0.0f (inclusive) to 1.0f (exclusive), is
-        /// pseudorandomly generated and returned. All 2<sup>24</sup> possible
-        /// float values of the form <i>m x </i>2<sup>-24</sup>,
-        /// where <i>m</i> is a positive integer less than 2<sup>24</sup>, are
-        /// produced with (approximately) equal probability.
-        /// <br/>The public implementation uses the upper 24 bits of <see cref="NextULong()"/>,
-        /// with a right shift and a multiply by a very small float
-        /// (5.9604645E-8f). It tends to be fast if
-        /// NextULong() is fast, but alternative implementations could use 24 bits of
-        /// <see cref="NextInt()"/> (or just <see cref="NextBits(int)"/>, giving it 24)
-        /// if that generator doesn't efficiently generate 64-bit longs.</remarks>
-        /// <returns>the next pseudorandom, uniformly distributed float
-        /// value between 0.0 and 1.0 from this
-        /// random number generator's sequence</returns>
+        /// <inheritdoc />
         public virtual float NextFloat()
         {
             return (NextULong() >> 40) * FLOAT_ADJUST;
         }
 
-        /// <summary>
-        /// Gets a pseudo-random float between 0 (inclusive) and outerBound (exclusive).
-        /// The outerBound may be positive or negative.
-        /// Exactly the same as {@code NextFloat() * outerBound}.
-        /// <param name="outerBound">the exclusive outer bound</param>
-        /// <returns>a float between 0 (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public float NextFloat(float outerBound)
         {
             return NextFloat() * outerBound;
         }
 
-        /// <summary>
-        /// Gets a pseudo-random float between innerBound (inclusive) and outerBound (exclusive).
-        /// Either, neither, or both of innerBound and outerBound may be negative; this does not change which is
-        /// inclusive and which is exclusive.
-        /// <param name="innerBound">the inclusive inner bound; may be negative</param>
-        /// <param name="outerBound">the exclusive outer bound; may be negative</param>
-        /// <returns>a float between innerBound (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public float NextFloat(float innerBound, float outerBound)
         {
             return innerBound + NextFloat() * (outerBound - innerBound);
         }
 
-        /// <summary>
-        /// Returns the next pseudorandom, uniformly distributed
-        /// double value between 0.0 (inclusive) and 1.0
-        /// (exclusive) from this random number generator's sequence.
-        /// </summary>
-        /// <remarks>
-        /// The general contract of NextDouble is that one
-        /// double value, chosen (approximately) uniformly from the
-        /// range 0.0 (inclusive) to 1.0 (exclusive), is
-        /// pseudorandomly generated and returned.
-        /// <br/>The default implementation uses the upper 53 bits of <see cref="NextLong()"/>,
-        /// with an unsigned right shift and a multiply by a very small double
-        /// (1.1102230246251565E-16). It should perform well
-        /// if nextLong() performs well, and is expected to perform less well if the
-        /// generator naturally produces 32 or fewer bits at a time.\
-        /// </remarks>
-        /// <returns>the next pseudorandom, uniformly distributed double
-        /// value between 0.0 and 1.0 from this
-        /// random number generator's sequence</returns>
+
+        /// <inheritdoc />
         public virtual double NextDouble()
         {
             return (NextULong() >> 11) * DOUBLE_ADJUST;
         }
 
-        /// <summary>
-        /// Gets a pseudo-random double between 0 (inclusive) and outerBound (exclusive).
-        /// The outerBound may be positive or negative.
-        /// Exactly the same as {@code NextDouble() * outerBound}.
-        /// <param name="outerBound">the exclusive outer bound</param>
-        /// <returns>a double between 0 (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public double NextDouble(double outerBound)
         {
             return NextDouble() * outerBound;
         }
 
-        /// <summary>
-        /// Gets a pseudo-random double between innerBound (inclusive) and outerBound (exclusive).
-        /// Either, neither, or both of innerBound and outerBound may be negative; this does not change which is
-        /// inclusive and which is exclusive.
-        /// <param name="innerBound">the inclusive inner bound; may be negative</param>
-        /// <param name="outerBound">the exclusive outer bound; may be negative</param>
-        /// <returns>a double between innerBound (inclusive) and outerBound (exclusive)</returns>
+        /// <inheritdoc />
         public double NextDouble(double innerBound, double outerBound)
         {
             return innerBound + NextDouble() * (outerBound - innerBound);
         }
 
-        /// <summary>
-        /// This is just like <see cref="NextDouble()"/>, returning a double between 0 and 1, except that it is inclusive on both 0.0 and 1.0.
-        /// It returns 1.0 extremely rarely, 0.000000000000011102230246251565% of the time if there is no bias in the generator, but it
-        /// can happen. This uses <see cref="nextLong(long)"/> internally, so it may have some bias towards or against specific
-        /// subtly-different results.
-        /// <returns>a double between 0.0, inclusive, and 1.0, inclusive</returns>
+        /// <inheritdoc />
         public double NextInclusiveDouble()
         {
             return NextULong(0x20000000000001L) * DOUBLE_ADJUST;
         }
 
-        /// <summary>
-        /// Just like <see cref="NextDouble(double)"/>, but this is inclusive on both 0.0 and outerBound.
-        /// It may be important to note that it returns outerBound on only 0.000000000000011102230246251565% of calls.
-        /// <param name="outerBound">the outer inclusive bound; may be positive or negative</param>
-        /// <returns>a double between 0.0, inclusive, and outerBound, inclusive</returns>
+        /// <inheritdoc />
         public double NextInclusiveDouble(double outerBound)
         {
             return NextInclusiveDouble() * outerBound;
         }
 
-        /// <summary>
-        /// Just like <see cref="NextDouble(double, double)"/>, but this is inclusive on both innerBound and outerBound.
-        /// It may be important to note that it returns outerBound on only 0.000000000000011102230246251565% of calls, if it can
-        /// return it at all because of floating-point imprecision when innerBound is a larger number.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer inclusive bound; may be positive or negative</param>
-        /// <returns>a double between innerBound, inclusive, and outerBound, inclusive</returns>
+        /// <inheritdoc />
         public double NextInclusiveDouble(double innerBound, double outerBound)
         {
             return innerBound + NextInclusiveDouble() * (outerBound - innerBound);
         }
 
-        /// <summary>
-        /// This is just like <see cref="NextFloat()"/>, returning a float between 0 and 1, except that it is inclusive on both 0.0 and 1.0.
-        /// It returns 1.0 rarely, 0.00000596046412226771% of the time if there is no bias in the generator, but it can happen. This method
-        /// has been tested by generating 268435456 (or 0x10000000) random ints with <see cref="nextInt(int)"/>, and just before the end of that
-        /// it had generated every one of the 16777217 roughly-equidistant floats this is able to produce. Not all seeds and streams are
-        /// likely to accomplish that in the same time, or at all, depending on the generator.
-        /// <returns>a float between 0.0, inclusive, and 1.0, inclusive</returns>
+        /// <inheritdoc />
         public float NextInclusiveFloat()
         {
             return NextInt(0x1000001) * FLOAT_ADJUST;
         }
 
-        /// <summary>
-        /// Just like <see cref="NextFloat(float)"/>, but this is inclusive on both 0.0 and outerBound.
-        /// It may be important to note that it returns outerBound on only 0.00000596046412226771% of calls.
-        /// <param name="outerBound">the outer inclusive bound; may be positive or negative</param>
-        /// <returns>a float between 0.0, inclusive, and outerBound, inclusive</returns>
+        /// <inheritdoc />
         public float NextInclusiveFloat(float outerBound)
         {
             return NextInclusiveFloat() * outerBound;
         }
 
-        /// <summary>
-        /// Just like <see cref="NextFloat(float, float)"/>, but this is inclusive on both innerBound and outerBound.
-        /// It may be important to note that it returns outerBound on only 0.00000596046412226771% of calls, if it can return
-        /// it at all because of floating-point imprecision when innerBound is a larger number.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer inclusive bound; may be positive or negative</param>
-        /// <returns>a float between innerBound, inclusive, and outerBound, inclusive</returns>
+        /// <inheritdoc />
         public float NextInclusiveFloat(float innerBound, float outerBound)
         {
             return innerBound + NextInclusiveFloat() * (outerBound - innerBound);
@@ -1684,36 +1366,21 @@ namespace ShaiRandom
             return BitConverter.Int64BitsToDouble((0x7C10000000000000L + (BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) & -0x0010000000000000L)) | (~bits & 0x000FFFFFFFFFFFFFL));
         }
 
-        /// <summary>
-        /// Just like <see cref="NextDouble(double)"/>, but this is exclusive on both 0.0 and outerBound.
-        /// Like <see cref="nextExclusiveDouble()"/>, which this uses, this may have better bit-distribution of
-        /// double values, and it may also be better able to produce very small doubles when outerBound is large.
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <returns>a double between 0.0, exclusive, and outerBound, exclusive</returns>
+
+        /// <inheritdoc />
         public double NextExclusiveDouble(double outerBound)
         {
             return NextExclusiveDouble() * outerBound;
         }
 
-        /// <summary>
-        /// Just like <see cref="NextDouble(double, double)"/>, but this is exclusive on both innerBound and outerBound.
-        /// Like <see cref="nextExclusiveDouble()"/>, which this uses,, this may have better bit-distribution of double values,
-        /// and it may also be better able to produce doubles close to innerBound when {@code outerBound - innerBound} is large.
-        /// <param name="innerBound">the inner exclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <returns>a double between innerBound, exclusive, and outerBound, exclusive</returns>
+        /// <inheritdoc />
         public double NextExclusiveDouble(double innerBound, double outerBound)
         {
             return innerBound + NextExclusiveDouble() * (outerBound - innerBound);
         }
 
-        /// <summary>
-        /// Gets a random float between 0.0 and 1.0, exclusive at both ends. This can return float values between 1.0842022E-19 and 0.99999994; it cannot return 0 or 1.
-        /// </summary>
-        /// <remarks>
-        /// Like <see cref="NextExclusiveDouble()"/>, this is absolute voodoo code. Its implementation generates one long and then does conversions both from int to float
-        /// (to get the result), and from double to long (to get an approximation of log base 2). The code here is bat country, and should not be edited carelessly.</remarks>
-        /// <returns>A random uniform float between 0 and 1 (both exclusive).</returns>
+
+        /// <inheritdoc />
         public float NextExclusiveFloat()
         {
             // return ((NextUInt() >> 9) + 1u) * 5.960464E-8f;
@@ -1721,24 +1388,13 @@ namespace ShaiRandom
             return BitConverter.Int32BitsToSingle((1089 + (int)(BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) >> 52) << 23) | ((int)~bits & 0x007FFFFF));
         }
 
-        /// <summary>
-        /// Just like <see cref="NextFloat(float)"/>, but this is exclusive on both 0.0 and outerBound.
-        /// Like <see cref="nextExclusiveFloat()"/>, this may have better bit-distribution of float values, and
-        /// it may also be better able to produce very small floats when outerBound is large.
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <returns>a float between 0.0, exclusive, and outerBound, exclusive</returns>
+        /// <inheritdoc />
         public float NextExclusiveFloat(float outerBound)
         {
             return NextExclusiveFloat() * outerBound;
         }
 
-        /// <summary>
-        /// Just like <see cref="NextFloat(float, float)"/>, but this is exclusive on both innerBound and outerBound.
-        /// Like <see cref="nextExclusiveFloat()"/>, this may have better bit-distribution of float values, and
-        /// it may also be better able to produce floats close to innerBound when {@code outerBound - innerBound} is large.
-        /// <param name="innerBound">the inner exclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <returns>a float between innerBound, exclusive, and outerBound, exclusive</returns>
+        /// <inheritdoc />
         public float NextExclusiveFloat(float innerBound, float outerBound)
         {
             return innerBound + NextExclusiveFloat() * (outerBound - innerBound);
@@ -1816,12 +1472,7 @@ namespace ShaiRandom
             return Probit(NextExclusiveDouble()) * stdDev + mean;
         }
 
-        /// <summary>
-        /// (Optional) If implemented, this should jump the generator forward by the given number of steps as distance and return the result of NextULong()
-        /// as if called at that step. The distance can be negative if a long is cast to a ulong, which jumps backwards if the period of the generator is 2 to the 64.
-        /// </summary>
-        /// <param name="distance">How many steps to jump forward</param>
-        /// <returns>The result of what NextULong() would return at the now-current jumped state.</returns>
+        /// <inheritdoc />
         public virtual ulong Skip(ulong distance)
         {
             throw new NotSupportedException("Skip() is not implemented for this generator.");
@@ -1840,10 +1491,7 @@ namespace ShaiRandom
             return Skip(0xFFFFFFFFFFFFFFFFUL);
         }
 
-        /// <summary>
-        /// Returns a full copy (deep, if necessary) of this IEnhancedRandom.
-        /// </summary>
-        /// <returns>A copy of this IEnhancedRandom.</returns>
+        /// <inheritdoc />
         public abstract IEnhancedRandom Copy();
 
         /// <summary>
@@ -1893,20 +1541,13 @@ namespace ShaiRandom
             return true;
         }
 
-        /// <summary>
-        /// Returns true if a random value between 0 and 1 is less than the specified value.
-        /// </summary>
-        /// <param name="chance">A float between 0.0 and 1.0; higher values are more likely to result in true.</param>
-        /// <returns>a bool selected with the given chance of being true</returns>
+        /// <inheritdoc />
         public bool NextBool(float chance)
         {
             return NextFloat() < chance;
         }
 
-        /// <summary>
-        /// Returns -1 or 1, randomly.
-        /// </summary>
-        /// <returns>-1 or 1, selected with approximately equal likelihood</returns>
+        /// <inheritdoc />
         public int NextSign()
         {
             return 1 | NextInt() >> 31;
@@ -1945,14 +1586,8 @@ namespace ShaiRandom
             return max - MathF.Sqrt((1 - u) * d * (max - mode));
         }
 
-        /// <summary>
-        /// Returns the minimum result of trials calls to <see cref="NextInt(int, int)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the lower the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the lowest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+
+        /// <inheritdoc />
         public int MinIntOf(int innerBound, int outerBound, int trials)
         {
             int v = NextInt(innerBound, outerBound);
@@ -1963,14 +1598,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the maximum result of trials calls to <see cref="NextInt(int, int)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the higher the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the highest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public int MaxIntOf(int innerBound, int outerBound, int trials)
         {
             int v = NextInt(innerBound, outerBound);
@@ -1981,14 +1609,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the minimum result of trials calls to <see cref="NextLong(long, long)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the lower the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the lowest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public long MinLongOf(long innerBound, long outerBound, int trials)
         {
             long v = NextLong(innerBound, outerBound);
@@ -1999,14 +1620,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the maximum result of trials calls to <see cref="NextLong(long, long)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the higher the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the highest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public long MaxLongOf(long innerBound, long outerBound, int trials)
         {
             long v = NextLong(innerBound, outerBound);
@@ -2017,14 +1631,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the minimum result of trials calls to <see cref="NextUInt(int, int)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the lower the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the lowest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public uint MinUIntOf(uint innerBound, uint outerBound, int trials)
         {
             uint v = NextUInt(innerBound, outerBound);
@@ -2035,14 +1642,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the maximum result of trials calls to <see cref="NextUInt(int, int)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the higher the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the highest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public uint MaxUIntOf(uint innerBound, uint outerBound, int trials)
         {
             uint v = NextUInt(innerBound, outerBound);
@@ -2053,14 +1653,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the minimum result of trials calls to <see cref="NextULong(long, long)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the lower the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the lowest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public ulong MinULongOf(ulong innerBound, ulong outerBound, int trials)
         {
             ulong v = NextULong(innerBound, outerBound);
@@ -2071,14 +1664,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the maximum result of trials calls to <see cref="NextULong(long, long)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the higher the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the highest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public ulong MaxULongOf(ulong innerBound, ulong outerBound, int trials)
         {
             ulong v = NextULong(innerBound, outerBound);
@@ -2089,14 +1675,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the minimum result of trials calls to <see cref="NextDouble(double, double)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the lower the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the lowest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public double MinDoubleOf(double innerBound, double outerBound, int trials)
         {
             double v = NextDouble(innerBound, outerBound);
@@ -2107,14 +1686,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the maximum result of trials calls to <see cref="NextDouble(double, double)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the higher the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the highest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public double MaxDoubleOf(double innerBound, double outerBound, int trials)
         {
             double v = NextDouble(innerBound, outerBound);
@@ -2125,14 +1697,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the minimum result of trials calls to <see cref="NextFloat(float, float)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the lower the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the lowest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public float MinFloatOf(float innerBound, float outerBound, int trials)
         {
             float v = NextFloat(innerBound, outerBound);
@@ -2143,14 +1708,7 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Returns the maximum result of trials calls to <see cref="NextFloat(float, float)"/> using the given innerBound
-        /// and outerBound. The innerBound is inclusive; the outerBound is exclusive.
-        /// The higher trials is, the higher the average value this returns.
-        /// <param name="innerBound">the inner inclusive bound; may be positive or negative</param>
-        /// <param name="outerBound">the outer exclusive bound; may be positive or negative</param>
-        /// <param name="trials">how many random numbers to acquire and compare</param>
-        /// <returns>the highest random number between innerBound (inclusive) and outerBound (exclusive) this found</returns>
+        /// <inheritdoc />
         public float MaxFloatOf(float innerBound, float outerBound, int trials)
         {
             float v = NextFloat(innerBound, outerBound);
@@ -2161,23 +1719,13 @@ namespace ShaiRandom
             return v;
         }
 
-        /// <summary>
-        /// Gets a randomly-chosen item from the given non-null, non-empty array.
-        /// </summary>
-        /// <typeparam name="T">The type of items in the array.</typeparam>
-        /// <param name="array">Must be non-null and non-empty.</param>
-        /// <returns>A randomly-chosen item from array.</returns>
+        /// <inheritdoc />
         public T RandomElement<T>(T[] array)
         {
             return array[NextInt(array.Length)];
         }
 
-        /// <summary>
-        /// Gets a randomly-chosen item from the given non-null, non-empty IList.
-        /// </summary>
-        /// <typeparam name="T">The type of items in the list.</typeparam>
-        /// <param name="list">Must be non-null and non-empty.</param>
-        /// <returns>A randomly-chosen item from list.</returns>
+        /// <inheritdoc />
         public T RandomElement<T>(IList<T> list)
         {
             return list[NextInt(list.Count)];
@@ -2214,11 +1762,10 @@ namespace ShaiRandom
             for (int i = offset + length - 1; i > offset; i--)
             {
                 int ii = NextInt(offset, i + 1);
-                T temp = items[i];
-                items[i] = items[ii];
-                items[ii] = temp;
+                (items[i], items[ii]) = (items[ii], items[i]);
             }
         }
+        
         /// <summary>
         /// Shuffles a section of the given IList in-place pseudo-randomly, using this to generate
         /// {@code length - 1} random numbers and using the Fisher-Yates (also called Knuth) shuffle algorithm.
@@ -2232,9 +1779,7 @@ namespace ShaiRandom
             for (int i = offset + length - 1; i > offset; i--)
             {
                 int ii = NextInt(offset, i + 1);
-                T temp = items[i];
-                items[i] = items[ii];
-                items[ii] = temp;
+                (items[i], items[ii]) = (items[ii], items[i]);
             }
         }
 

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -21,14 +21,14 @@ namespace ShaiRandom
         /**
          * The first state; can be any ulong.
          */
-        public ulong state { get; set; }
+        public ulong State { get; set; }
 
         /**
          * Creates a new DistinctRandom with a random state.
          */
         public DistinctRandom()
         {
-            state = MakeSeed();
+            State = MakeSeed();
         }
 
         /**
@@ -38,7 +38,7 @@ namespace ShaiRandom
          */
         public DistinctRandom(ulong seed)
         {
-            this.state = seed;
+            State = seed;
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace ShaiRandom
          */
         public override ulong SelectState(int selection)
         {
-            return state;
+            return State;
         }
 
         /**
@@ -79,7 +79,7 @@ namespace ShaiRandom
          */
         public override void SetSelectedState(int selection, ulong value)
         {
-            state = value;
+            State = value;
         }
 
         /**
@@ -89,7 +89,7 @@ namespace ShaiRandom
          */
         public override void Seed(ulong seed)
         {
-            state = seed;
+            State = seed;
         }
 
         /**
@@ -99,14 +99,15 @@ namespace ShaiRandom
          */
         public override void SetState(ulong state)
         {
-            this.state = state;
+            this.State = state;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
             unchecked
             {
-                ulong x = (state += 0x9E3779B97F4A7C15UL);
+                ulong x = (State += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
@@ -115,11 +116,12 @@ namespace ShaiRandom
             }
         }
 
+        /// <inheritdoc />
         public override ulong Skip(ulong distance)
         {
             unchecked
             {
-                ulong x = (state += 0x9E3779B97F4A7C15UL * distance);
+                ulong x = (State += 0x9E3779B97F4A7C15UL * distance);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
@@ -128,11 +130,12 @@ namespace ShaiRandom
             }
         }
 
+        /// <inheritdoc />
         public override ulong PreviousULong()
         {
             unchecked
             {
-                ulong x = (state -= 0x9E3779B97F4A7C15UL);
+                ulong x = (State -= 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
@@ -141,18 +144,28 @@ namespace ShaiRandom
             }
         }
 
-        public override IEnhancedRandom Copy() => new DistinctRandom(state);
-        public override string StringSerialize() => $"#DisR`{state:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new DistinctRandom(State);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#DisR`{State:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            state = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            State = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as DistinctRandom);
-        public bool Equals(DistinctRandom? other) => other != null && state == other.state;
-        public override int GetHashCode() => HashCode.Combine(state);
+
+        /// <inheritdoc />
+        public bool Equals(DistinctRandom? other) => other != null && State == other.State;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(State);
 
         public static bool operator ==(DistinctRandom? left, DistinctRandom? right) => EqualityComparer<DistinctRandom>.Default.Equals(left, right);
         public static bool operator !=(DistinctRandom? left, DistinctRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 1 state, more here later. This one supports <see cref="Skip(ulong)"/>.

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -21,30 +21,30 @@ namespace ShaiRandom
         /**
          * The first state; can be any long.
          */
-        public ulong stateA { get; set; }
+        public ulong StateA { get; set; }
         /**
          * The second state; can be any long.
          */
-        public ulong stateB { get; set; }
+        public ulong StateB { get; set; }
         /**
          * The third state; can be any long.
          */
-        public ulong stateC { get; set; }
+        public ulong StateC { get; set; }
         /**
          * The fourth state; can be any long. If this has just been set to some value, then the next call to
          * {@link #nextLong()} will return that value as-is. Later calls will be more random.
          */
-        public ulong stateD { get; set; }
+        public ulong StateD { get; set; }
 
         /**
          * Creates a new FourWheelRandom with a random state.
          */
         public FourWheelRandom()
         {
-            stateA = MakeSeed();
-            stateB = MakeSeed();
-            stateC = MakeSeed();
-            stateD = MakeSeed();
+            StateA = MakeSeed();
+            StateB = MakeSeed();
+            StateC = MakeSeed();
+            StateD = MakeSeed();
         }
 
         /**
@@ -67,10 +67,10 @@ namespace ShaiRandom
          */
         public FourWheelRandom(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
+            StateD = stateD;
         }
 
         /// <summary>
@@ -104,13 +104,13 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    return stateA;
+                    return StateA;
                 case 1:
-                    return stateB;
+                    return StateB;
                 case 2:
-                    return stateC;
+                    return StateC;
                 default:
-                    return stateD;
+                    return StateD;
             }
         }
 
@@ -126,16 +126,16 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    stateA = value;
+                    StateA = value;
                     break;
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 case 2:
-                    stateC = value;
+                    StateC = value;
                     break;
                 default:
-                    stateD = value;
+                    StateD = value;
                     break;
             }
         }
@@ -156,25 +156,25 @@ namespace ShaiRandom
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateA = x ^ x >> 27;
+                StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateB = x ^ x >> 27;
+                StateB = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateC = x ^ x >> 27;
+                StateC = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateD = x ^ x >> 27;
+                StateD = x ^ x >> 27;
             }
         }
 
@@ -192,58 +192,70 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
+            StateD = stateD;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
-            ulong fa = stateA;
-            ulong fb = stateB;
-            ulong fc = stateC;
-            ulong fd = stateD;
+            ulong fa = StateA;
+            ulong fb = StateB;
+            ulong fc = StateC;
+            ulong fd = StateD;
             unchecked
             {
-                stateA = 0xD1342543DE82EF95UL * fd;
-                stateB = fa + 0xC6BC279692B5C323UL;
-                stateC = fb.RotateLeft(47) - fd;
-                stateD = fb ^ fc;
+                StateA = 0xD1342543DE82EF95UL * fd;
+                StateB = fa + 0xC6BC279692B5C323UL;
+                StateC = fb.RotateLeft(47) - fd;
+                StateD = fb ^ fc;
             }
             return fd;
         }
 
+        /// <inheritdoc />
         public override ulong PreviousULong()
         {
-            ulong fa = stateA;
-            ulong fb = stateB;
-            ulong fc = stateC;
+            ulong fa = StateA;
+            ulong fb = StateB;
+            ulong fc = StateC;
             unchecked
             {
-                stateD = 0x572B5EE77A54E3BDUL * fa;
-                stateA = fb - 0xC6BC279692B5C323UL;
-                stateB = BitExtensions.RotateRight(fc + stateD, 47);
-                stateC = stateD ^ stateB;
-                return 0x572B5EE77A54E3BDUL * stateA;
+                StateD = 0x572B5EE77A54E3BDUL * fa;
+                StateA = fb - 0xC6BC279692B5C323UL;
+                StateB = (fc + StateD).RotateRight(47);
+                StateC = StateD ^ StateB;
+                return 0x572B5EE77A54E3BDUL * StateA;
             }
         }
 
-        public override IEnhancedRandom Copy() => new FourWheelRandom(stateA, stateB, stateC, stateD);
-        public override string StringSerialize() => $"#FoWR`{stateA:X}~{stateB:X}~{stateC:X}~{stateD:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new FourWheelRandom(StateA, StateB, StateC, StateD);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#FoWR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as FourWheelRandom);
-        public bool Equals(FourWheelRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB && stateC == other.stateC && stateD == other.stateD;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB, stateC, stateD);
+
+        /// <inheritdoc />
+        public bool Equals(FourWheelRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC && StateD == other.StateD;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC, StateD);
 
         public static bool operator ==(FourWheelRandom? left, FourWheelRandom? right) => EqualityComparer<FourWheelRandom>.Default.Equals(left, right);
         public static bool operator !=(FourWheelRandom? left, FourWheelRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 4 states, more here later.

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -16,22 +16,22 @@ namespace ShaiRandom.Generators
     /// </remarks>
     public class KnownSeriesRandom : AbstractRandom, IEquatable<KnownSeriesRandom?>
     {
-        private int boolIndex;
-        private List<bool> boolSeries;
-        private int byteIndex;
-        private List<byte> byteSeries;
-        private int doubleIndex;
-        private List<double> doubleSeries;
-        private int floatIndex;
-        private List<float> floatSeries;
-        private int intIndex;
-        private List<int> intSeries;
-        private int uintIndex;
-        private List<uint> uintSeries;
-        private int longIndex;
-        private List<long> longSeries;
-        private int ulongIndex;
-        private List<ulong> ulongSeries;
+        private int _boolIndex;
+        private readonly List<bool> _boolSeries;
+        private int _byteIndex;
+        private readonly List<byte> _byteSeries;
+        private int _doubleIndex;
+        private readonly List<double> _doubleSeries;
+        private int _floatIndex;
+        private readonly List<float> _floatSeries;
+        private int _intIndex;
+        private readonly List<int> _intSeries;
+        private int _uintIndex;
+        private readonly List<uint> _uintSeries;
+        private int _longIndex;
+        private readonly List<long> _longSeries;
+        private int _ulongIndex;
+        private readonly List<ulong> _ulongSeries;
 
         public KnownSeriesRandom() : this(0UL)
         {
@@ -42,16 +42,16 @@ namespace ShaiRandom.Generators
             Seed(seed);
         }
 
-        public KnownSeriesRandom(KnownSeriesRandom other) : this(other.intSeries, other.uintSeries, other.doubleSeries, other.boolSeries, other.byteSeries, other.floatSeries, other.longSeries, other.ulongSeries)
+        public KnownSeriesRandom(KnownSeriesRandom other) : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries)
         {
-            intIndex = other.intIndex;
-            uintIndex = other.uintIndex;
-            doubleIndex = other.doubleIndex;
-            boolIndex = other.boolIndex;
-            byteIndex = other.byteIndex;
-            floatIndex = other.floatIndex;
-            longIndex = other.longIndex;
-            ulongIndex = other.ulongIndex;
+            _intIndex = other._intIndex;
+            _uintIndex = other._uintIndex;
+            _doubleIndex = other._doubleIndex;
+            _boolIndex = other._boolIndex;
+            _byteIndex = other._byteIndex;
+            _floatIndex = other._floatIndex;
+            _longIndex = other._longIndex;
+            _ulongIndex = other._ulongIndex;
         }
 
         /// <summary>
@@ -64,61 +64,79 @@ namespace ShaiRandom.Generators
             IEnumerable<float>? floatSeries = null, IEnumerable<long>? longSeries = null, IEnumerable<ulong>? ulongSeries = null) : base(0UL)
         {
             if (intSeries == null)
-                this.intSeries = new List<int>();
+                _intSeries = new List<int>();
             else
-                this.intSeries = intSeries.ToList();
+                _intSeries = intSeries.ToList();
 
             if (uintSeries == null)
-                this.uintSeries = new List<uint>();
+                _uintSeries = new List<uint>();
             else
-                this.uintSeries = uintSeries.ToList();
+                _uintSeries = uintSeries.ToList();
 
             if (longSeries == null)
-                this.longSeries = new List<long>();
+                _longSeries = new List<long>();
             else
-                this.longSeries = longSeries.ToList();
+                _longSeries = longSeries.ToList();
 
             if (ulongSeries == null)
-                this.ulongSeries = new List<ulong>();
+                _ulongSeries = new List<ulong>();
             else
-                this.ulongSeries = ulongSeries.ToList();
+                _ulongSeries = ulongSeries.ToList();
 
             if (doubleSeries == null)
-                this.doubleSeries = new List<double>();
+                _doubleSeries = new List<double>();
             else
-                this.doubleSeries = doubleSeries.ToList();
+                _doubleSeries = doubleSeries.ToList();
 
             if (floatSeries == null)
-                this.floatSeries = new List<float>();
+                _floatSeries = new List<float>();
             else
-                this.floatSeries = floatSeries.ToList();
+                _floatSeries = floatSeries.ToList();
 
             if (boolSeries == null)
-                this.boolSeries = new List<bool>();
+                _boolSeries = new List<bool>();
             else
-                this.boolSeries = boolSeries.ToList();
+                _boolSeries = boolSeries.ToList();
 
             if (byteSeries == null)
-                this.byteSeries = new List<byte>();
+                _byteSeries = new List<byte>();
             else
-                this.byteSeries = byteSeries.ToList();
+                _byteSeries = byteSeries.ToList();
         }
 
+        /// <summary>
+        /// This generator has 8 states; one for each type of IEnumerable taken in the constructor.
+        /// </summary>
         public override int StateCount => 8;
 
+        /// <summary>
+        /// This supports <see cref="SelectState(int)"/>.
+        /// </summary>
         public override bool SupportsReadAccess => true;
 
+        /// <summary>
+        /// This supports <see cref="SetSelectedState(int, ulong)"/>.
+        /// </summary>
         public override bool SupportsWriteAccess => true;
 
+        /// <summary>
+        /// This does NOT support <see cref="IEnhancedRandom.Skip(ulong)"/>.
+        /// </summary>
         public override bool SupportsSkip => false;
 
+        /// <summary>
+        /// This does NOT support <see cref="PreviousULong()"/>.
+        /// </summary>
         public override bool SupportsPrevious => false;
 
+        /// <summary>
+        /// Generator is not serializable, and thus has no tag.
+        /// </summary>
         public override string Tag => "";
 
-        private static T returnIfRange<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
+        private static T ReturnIfRange<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
         {
-            T value = returnValueFrom(series, ref seriesIndex);
+            T value = ReturnValueFrom(series, ref seriesIndex);
 
             if (minValue.CompareTo(value) < 0)
                 throw new ArgumentException("Value returned is less than minimum value.");
@@ -129,9 +147,9 @@ namespace ShaiRandom.Generators
             return value;
         }
 
-        private static T returnIfRangeBothExclusive<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
+        private static T ReturnIfRangeBothExclusive<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
         {
-            T value = returnValueFrom(series, ref seriesIndex);
+            T value = ReturnValueFrom(series, ref seriesIndex);
 
             if (minValue.CompareTo(value) <= 0)
                 throw new ArgumentException("Value returned is less than/equal to minimum value.");
@@ -142,9 +160,9 @@ namespace ShaiRandom.Generators
             return value;
         }
 
-        private static T returnIfRangeInclusive<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
+        private static T ReturnIfRangeInclusive<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
         {
-            T value = returnValueFrom(series, ref seriesIndex);
+            T value = ReturnValueFrom(series, ref seriesIndex);
 
             if (minValue.CompareTo(value) < 0)
                 throw new ArgumentException("Value returned is less than minimum value.");
@@ -155,7 +173,7 @@ namespace ShaiRandom.Generators
             return value;
         }
 
-        private static T returnValueFrom<T>(List<T> series, ref int seriesIndex)
+        private static T ReturnValueFrom<T>(IReadOnlyList<T> series, ref int seriesIndex)
         {
             if (series.Count == 0)
                 throw new NotSupportedException("Tried to get value of type " + typeof(T).Name + ", but the KnownSeriesGenerator was not given any values of that type.");
@@ -174,7 +192,7 @@ namespace ShaiRandom.Generators
         /// <remarks>
         /// A modified modulo operator. Returns the result of  the formula
         /// (<paramref name="num"/> % <paramref name="wrapTo"/> + <paramref name="wrapTo"/>) % <paramref name="wrapTo"/>.
-        /// 
+        ///
         /// Practically it differs from regular modulo in that the values it returns when negative values for <paramref name="num"/>
         /// are wrapped around like one would want an array index to (if wrapTo is list.length, -1 wraps to list.length - 1). For example,
         /// 0 % 3 = 0, -1 % 3 = -1, -2 % 3 = -2, -3 % 3 = 0, and so forth, but WrapTo(0, 3) = 0,
@@ -195,14 +213,23 @@ namespace ShaiRandom.Generators
         /// wrapTo - 1], inclusive.
         /// </returns>
         private static int WrapAround(int num, int wrapTo) => (num % wrapTo + wrapTo) % wrapTo;
+
+        /// <inheritdoc />
         public override IEnhancedRandom Copy() => new KnownSeriesRandom(this);
-        public override bool Equals(object? obj) => obj is KnownSeriesRandom random && StateCount == random.StateCount && boolIndex == random.boolIndex && EqualityComparer<List<bool>>.Default.Equals(boolSeries, random.boolSeries) && byteIndex == random.byteIndex && EqualityComparer<List<byte>>.Default.Equals(byteSeries, random.byteSeries) && doubleIndex == random.doubleIndex && EqualityComparer<List<double>>.Default.Equals(doubleSeries, random.doubleSeries) && floatIndex == random.floatIndex && EqualityComparer<List<float>>.Default.Equals(floatSeries, random.floatSeries) && intIndex == random.intIndex && EqualityComparer<List<int>>.Default.Equals(intSeries, random.intSeries) && uintIndex == random.uintIndex && EqualityComparer<List<uint>>.Default.Equals(uintSeries, random.uintSeries) && longIndex == random.longIndex && EqualityComparer<List<long>>.Default.Equals(longSeries, random.longSeries) && ulongIndex == random.ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(ulongSeries, random.ulongSeries);
-        public bool Equals(KnownSeriesRandom? random) => random != null && StateCount == random.StateCount && boolIndex == random.boolIndex && EqualityComparer<List<bool>>.Default.Equals(boolSeries, random.boolSeries) && byteIndex == random.byteIndex && EqualityComparer<List<byte>>.Default.Equals(byteSeries, random.byteSeries) && doubleIndex == random.doubleIndex && EqualityComparer<List<double>>.Default.Equals(doubleSeries, random.doubleSeries) && floatIndex == random.floatIndex && EqualityComparer<List<float>>.Default.Equals(floatSeries, random.floatSeries) && intIndex == random.intIndex && EqualityComparer<List<int>>.Default.Equals(intSeries, random.intSeries) && uintIndex == random.uintIndex && EqualityComparer<List<uint>>.Default.Equals(uintSeries, random.uintSeries) && longIndex == random.longIndex && EqualityComparer<List<long>>.Default.Equals(longSeries, random.longSeries) && ulongIndex == random.ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(ulongSeries, random.ulongSeries);
-        public override bool NextBool() => returnValueFrom(boolSeries, ref boolIndex);
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => obj is KnownSeriesRandom random && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
+
+        /// <inheritdoc />
+        public bool Equals(KnownSeriesRandom? random) => random != null && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
+
+        public override bool NextBool() => ReturnValueFrom(_boolSeries, ref _boolIndex);
+
         public new bool NextBool(float chance) => NextBool();
 
-        public new int NextInt() => returnValueFrom(intSeries, ref intIndex);
+        public new int NextInt() => ReturnValueFrom(_intSeries, ref _intIndex);
         public new int NextInt(int outerBound) => NextInt(0, outerBound);
+
         /// <summary>
         /// Returns the next integer in the underlying series. If the value is less than
         /// <paramref name="minValue"/>, or greater than/equal to <paramref name="maxValue"/>, throws an exception.
@@ -210,8 +237,8 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next integer in the underlying series.</returns>
-        public new int NextInt(int minValue, int maxValue) => returnIfRange(minValue, maxValue, intSeries, ref intIndex);
-        public new uint NextUInt() => returnValueFrom(uintSeries, ref uintIndex);
+        public new int NextInt(int minValue, int maxValue) => ReturnIfRange(minValue, maxValue, _intSeries, ref _intIndex);
+        public new uint NextUInt() => ReturnValueFrom(_uintSeries, ref _uintIndex);
         public new uint NextUInt(uint outerBound) => NextUInt(0, outerBound);
         public new uint NextBits(int bits) => (bits & 31) == 0 ? NextUInt() : NextUInt(0, 1U << bits);
 
@@ -222,25 +249,26 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next unsigned integer in the underlying series.</returns>
-        public new uint NextUInt(uint minValue, uint maxValue) => returnIfRange(minValue, maxValue, uintSeries, ref uintIndex);
-        public override double NextDouble() => returnValueFrom(doubleSeries, ref doubleIndex);
+        public new uint NextUInt(uint minValue, uint maxValue) => ReturnIfRange(minValue, maxValue, _uintSeries, ref _uintIndex);
+
+        public override double NextDouble() => ReturnValueFrom(_doubleSeries, ref _doubleIndex);
         public new double NextDouble(double outerBound) => NextDouble(0.0, outerBound);
-        public new double NextDouble(double minBound, double maxBound) => returnIfRange(minBound, maxBound, doubleSeries, ref doubleIndex);
+        public new double NextDouble(double minBound, double maxBound) => ReturnIfRange(minBound, maxBound, _doubleSeries, ref _doubleIndex);
         public new double NextInclusiveDouble() => NextInclusiveDouble(0f, 1f);
         public new double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0f, outerBound);
-        public new double NextInclusiveDouble(double minBound, double maxBound) => returnIfRangeInclusive(minBound, maxBound, doubleSeries, ref doubleIndex);
+        public new double NextInclusiveDouble(double minBound, double maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
         public new double NextExclusiveDouble() => NextExclusiveDouble(0f, 1f);
         public new double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0f, outerBound);
-        public new double NextExclusiveDouble(double minBound, double maxBound) => returnIfRangeBothExclusive(minBound, maxBound, doubleSeries, ref doubleIndex);
-        public override float NextFloat() => returnValueFrom(floatSeries, ref floatIndex);
+        public new double NextExclusiveDouble(double minBound, double maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
+        public override float NextFloat() => ReturnValueFrom(_floatSeries, ref _floatIndex);
         public new float NextFloat(float outerBound) => NextFloat(0f, outerBound);
-        public new float NextFloat(float minBound, float maxBound) => returnIfRange(minBound, maxBound, floatSeries, ref floatIndex);
+        public new float NextFloat(float minBound, float maxBound) => ReturnIfRange(minBound, maxBound, _floatSeries, ref _floatIndex);
         public new float NextInclusiveFloat() => NextInclusiveFloat(0f, 1f);
         public new float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0f, outerBound);
-        public new float NextInclusiveFloat(float minBound, float maxBound) => returnIfRangeInclusive(minBound, maxBound, floatSeries, ref floatIndex);
+        public new float NextInclusiveFloat(float minBound, float maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
         public new float NextExclusiveFloat() => NextExclusiveFloat(0f, 1f);
         public new float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
-        public new float NextExclusiveFloat(float minBound, float maxBound) => returnIfRangeBothExclusive(minBound, maxBound, floatSeries, ref floatIndex);
+        public new float NextExclusiveFloat(float minBound, float maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
         public new float NextTriangular()
         {
             NextFloat(); // Used only to advance state the same number of times.
@@ -248,7 +276,7 @@ namespace ShaiRandom.Generators
         }
         public new float NextTriangular(float min, float max) => NextExclusiveFloat(min, max);
         public new float NextTriangular(float min, float max, float mode) => NextExclusiveFloat(min, max);
-        public new long NextLong() => returnValueFrom(longSeries, ref longIndex);
+        public new long NextLong() => ReturnValueFrom(_longSeries, ref _longIndex);
         public new long NextLong(long outerBound) => NextLong(0, outerBound);
         /// <summary>
         /// Returns the next long in the underlying series. If the value is less than
@@ -257,9 +285,9 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next long in the underlying series.</returns>
-        public new long NextLong(long minValue, long maxValue) => returnIfRange(minValue, maxValue, longSeries, ref longIndex);
+        public new long NextLong(long minValue, long maxValue) => ReturnIfRange(minValue, maxValue, _longSeries, ref _longIndex);
 
-        public override ulong NextULong() => returnValueFrom(ulongSeries, ref ulongIndex);
+        public override ulong NextULong() => ReturnValueFrom(_ulongSeries, ref _ulongIndex);
         public new ulong NextULong(ulong outerBound) => NextULong(0, outerBound);
         /// <summary>
         /// Returns the next ulong in the underlying series. If the value is less than
@@ -268,7 +296,7 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next ulong in the underlying series.</returns>
-        public new ulong NextULong(ulong minValue, ulong maxValue) => returnIfRange(minValue, maxValue, ulongSeries, ref ulongIndex);
+        public new ulong NextULong(ulong minValue, ulong maxValue) => ReturnIfRange(minValue, maxValue, _ulongSeries, ref _ulongIndex);
 
 
         /// <summary>
@@ -278,47 +306,47 @@ namespace ShaiRandom.Generators
         public new void NextBytes(byte[] buffer)
         {
             for (int i = 0; i < buffer.Length; i++)
-                buffer[i] = returnValueFrom(byteSeries, ref byteIndex);
+                buffer[i] = ReturnValueFrom(_byteSeries, ref _byteIndex);
         }
         public override ulong PreviousULong() => throw new NotImplementedException();
         public override void Seed(ulong seed)
         {
             int idx = (int)seed;
-            intIndex = idx;
-            uintIndex = idx;
-            doubleIndex = idx;
-            boolIndex = idx;
-            byteIndex = idx;
-            floatIndex = idx;
-            longIndex = idx;
-            ulongIndex = idx;
+            _intIndex = idx;
+            _uintIndex = idx;
+            _doubleIndex = idx;
+            _boolIndex = idx;
+            _byteIndex = idx;
+            _floatIndex = idx;
+            _longIndex = idx;
+            _ulongIndex = idx;
         }
         public override ulong SelectState(int selection)
         {
             switch (selection)
             {
-                case 0: return (ulong)intIndex;
-                case 1: return (ulong)uintIndex;
-                case 2: return (ulong)doubleIndex;
-                case 3: return (ulong)boolIndex;
-                case 4: return (ulong)byteIndex;
-                case 5: return (ulong)floatIndex;
-                case 6: return (ulong)longIndex;
-                default: return (ulong)ulongIndex;
+                case 0: return (ulong)_intIndex;
+                case 1: return (ulong)_uintIndex;
+                case 2: return (ulong)_doubleIndex;
+                case 3: return (ulong)_boolIndex;
+                case 4: return (ulong)_byteIndex;
+                case 5: return (ulong)_floatIndex;
+                case 6: return (ulong)_longIndex;
+                default: return (ulong)_ulongIndex;
             }
         }
         public override void SetSelectedState(int selection, ulong value)
         {
             switch (selection)
             {
-                case 0: intIndex = (int)value; break;
-                case 1: uintIndex = (int)value; break;
-                case 2: doubleIndex = (int)value; break;
-                case 3: boolIndex = (int)value; break;
-                case 4: byteIndex = (int)value; break;
-                case 5: floatIndex = (int)value; break;
-                case 6: longIndex = (int)value; break;
-                default: ulongIndex = (int)value; break;
+                case 0: _intIndex = (int)value; break;
+                case 1: _uintIndex = (int)value; break;
+                case 2: _doubleIndex = (int)value; break;
+                case 3: _boolIndex = (int)value; break;
+                case 4: _byteIndex = (int)value; break;
+                case 5: _floatIndex = (int)value; break;
+                case 6: _longIndex = (int)value; break;
+                default: _ulongIndex = (int)value; break;
             }
         }
         public override void SetState(ulong state) => Seed(state);

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -21,12 +21,12 @@ namespace ShaiRandom
         /**
          * The first state; can be any ulong.
          */
-        public ulong stateA { get; set; }
+        public ulong StateA { get; set; }
         private ulong _b;
         /**
          * The second state; can be any odd ulong (the last bit must be 1)
          */
-        public ulong stateB { get
+        public ulong StateB { get
             {
                 return _b;
             }
@@ -41,8 +41,8 @@ namespace ShaiRandom
          */
         public LaserRandom()
         {
-            stateA = MakeSeed();
-            stateB = MakeSeed();
+            StateA = MakeSeed();
+            StateB = MakeSeed();
         }
 
         /**
@@ -63,8 +63,8 @@ namespace ShaiRandom
          */
         public LaserRandom(ulong stateA, ulong stateB)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
+            StateA = stateA;
+            StateB = stateB;
         }
 
         /// <summary>
@@ -98,9 +98,9 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 1:
-                    return stateB;
+                    return StateB;
                 default:
-                    return stateA;
+                    return StateA;
             }
         }
 
@@ -116,10 +116,10 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 default:
-                    stateA = value;
+                    StateA = value;
                     break;
             }
         }
@@ -138,7 +138,7 @@ namespace ShaiRandom
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateA = x ^ x >> 27;
+                StateA = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
@@ -157,55 +157,68 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
+            this.StateA = stateA;
+            this.StateB = stateB;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
             unchecked
             {
-                ulong s = (stateA += 0xC6BC279692B5C323UL);
+                ulong s = (StateA += 0xC6BC279692B5C323UL);
                 ulong z = (s ^ s >> 31) * (_b += 0x9E3779B97F4A7C16UL);
                 return z ^ z >> 26 ^ z >> 6;
             }
         }
 
+        /// <inheritdoc />
         public override ulong Skip(ulong distance)
         {
             unchecked
             {
-                ulong s = (stateA += 0xC6BC279692B5C323UL * distance);
+                ulong s = (StateA += 0xC6BC279692B5C323UL * distance);
                 ulong z = (s ^ s >> 31) * (_b += 0x9E3779B97F4A7C16UL * distance);
                 return z ^ z >> 26 ^ z >> 6;
             }
         }
 
+        /// <inheritdoc />
         public override ulong PreviousULong()
         {
             unchecked
             {
-                ulong z = stateA;
+                ulong z = StateA;
                 z = (z ^ z >> 31) * _b;
-                stateA -= 0xC6BC279692B5C323UL;
+                StateA -= 0xC6BC279692B5C323UL;
                 _b -= 0x9E3779B97F4A7C16UL;
                 return z ^ z >> 26 ^ z >> 6;
             }
         }
 
-        public override IEnhancedRandom Copy() => new LaserRandom(stateA, stateB);
-        public override string StringSerialize() => $"#LasR`{stateA:X}~{stateB:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new LaserRandom(StateA, StateB);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#LasR`{StateA:X}~{StateB:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as LaserRandom);
-        public bool Equals(LaserRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB);
+
+        /// <inheritdoc />
+        public bool Equals(LaserRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB);
 
         public static bool operator ==(LaserRandom? left, LaserRandom? right) => EqualityComparer<LaserRandom>.Default.Equals(left, right);
         public static bool operator !=(LaserRandom? left, LaserRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 2 states, more here later. This one supports <see cref="Skip(ulong)"/>.

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 2 states, more here later.

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -26,12 +26,12 @@ namespace ShaiRandom
         /**
          * The first state; can be any ulong.
          */
-        public ulong stateA { get; set; }
+        public ulong StateA { get; set; }
         private ulong _b;
         /**
          * The second state; can be any odd ulong (the last bit must be 1)
          */
-        public ulong stateB { get
+        public ulong StateB { get
             {
                 return _b;
             }
@@ -46,8 +46,8 @@ namespace ShaiRandom
          */
         public MizuchiRandom()
         {
-            stateA = MakeSeed();
-            stateB = MakeSeed();
+            StateA = MakeSeed();
+            StateB = MakeSeed();
         }
 
         /**
@@ -68,8 +68,8 @@ namespace ShaiRandom
          */
         public MizuchiRandom(ulong stateA, ulong stateB)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
+            StateA = stateA;
+            StateB = stateB;
         }
 
         /// <summary>
@@ -103,9 +103,9 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 1:
-                    return stateB;
+                    return StateB;
                 default:
-                    return stateA;
+                    return StateA;
             }
         }
 
@@ -121,10 +121,10 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 default:
-                    stateA = value;
+                    StateA = value;
                     break;
             }
         }
@@ -143,7 +143,7 @@ namespace ShaiRandom
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateA = x ^ x >> 27;
+                StateA = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
@@ -162,44 +162,56 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
+            StateA = stateA;
+            StateB = stateB;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
             unchecked
             {
-                ulong z = (stateA = stateA * 0xF7C2EBC08F67F2B5UL + stateB);
+                ulong z = (StateA = StateA * 0xF7C2EBC08F67F2B5UL + StateB);
                 z = (z ^ z >> 23 ^ z >> 47) * 0xAEF17502108EF2D9UL;
                 return z ^ z >> 25;
             }
         }
 
+        /// <inheritdoc />
         public override ulong PreviousULong()
         {
             unchecked
             {
-                ulong z = stateA;
-                stateA = (stateA - stateB) * 0x09795DFF8024EB9DUL;
+                ulong z = StateA;
+                StateA = (StateA - StateB) * 0x09795DFF8024EB9DUL;
                 z = (z ^ z >> 23 ^ z >> 47) * 0xAEF17502108EF2D9UL;
                 return z ^ z >> 25;
             }
         }
 
-        public override IEnhancedRandom Copy() => new MizuchiRandom(stateA, stateB);
-        public override string StringSerialize() => $"#MizR`{stateA:X}~{stateB:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new MizuchiRandom(StateA, StateB);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#MizR`{StateA:X}~{StateB:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as MizuchiRandom);
-        public bool Equals(MizuchiRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB);
+
+        /// <inheritdoc />
+        public bool Equals(MizuchiRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB);
 
         public static bool operator ==(MizuchiRandom? left, MizuchiRandom? right) => EqualityComparer<MizuchiRandom>.Default.Equals(left, right);
         public static bool operator !=(MizuchiRandom? left, MizuchiRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -20,7 +20,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 3 states, more here later. Implements the RomuTrio algorithm for fast ulongs.

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -43,13 +43,13 @@ namespace ShaiRandom
          * If this has just been set to some value, then the next call to
          * {@link #nextULong()} will return that value as-is. Later calls will be more random.
          */
-        public ulong stateA { get; set; }
+        public ulong StateA { get; set; }
 
         private ulong _b;
         /**
          * The second state; can be any long except that the whole state must not all be 0.
          */
-        public ulong stateB
+        public ulong StateB
         {
             get => _b;
             set => _b = value;
@@ -62,10 +62,10 @@ namespace ShaiRandom
          * If all other states are 0, and this would be set to 0,
          * then this is instead set to 0xFFFFFFFFFFFFFFFFUL.
          */
-        public ulong stateC
+        public ulong StateC
         {
             get => _c;
-            set => _c = (stateA | stateB | value) == 0UL ? 0xFFFFFFFFFFFFFFFFUL : value;
+            set => _c = (StateA | StateB | value) == 0UL ? 0xFFFFFFFFFFFFFFFFUL : value;
         }
 
         /**
@@ -73,9 +73,9 @@ namespace ShaiRandom
          */
         public RomuTrioRandom()
         {
-            stateA = MakeSeed();
-            stateB = MakeSeed();
-            stateC = MakeSeed();
+            StateA = MakeSeed();
+            StateB = MakeSeed();
+            StateC = MakeSeed();
         }
 
         /**
@@ -97,9 +97,9 @@ namespace ShaiRandom
          */
         public RomuTrioRandom(ulong stateA, ulong stateB, ulong stateC)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
         }
 
         /// <summary>
@@ -133,11 +133,11 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    return stateA;
+                    return StateA;
                 case 1:
-                    return stateB;
+                    return StateB;
                 default:
-                    return stateC;
+                    return StateC;
             }
         }
 
@@ -153,13 +153,13 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    stateA = value;
+                    StateA = value;
                     break;
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 default:
-                    stateC = value;
+                    StateC = value;
                     break;
             }
         }
@@ -180,19 +180,19 @@ namespace ShaiRandom
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateA = x ^ x >> 27;
+                StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateB = x ^ x >> 27;
+                StateB = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateC = x ^ x >> 27;
+                StateC = x ^ x >> 27;
             }
         }
 
@@ -209,17 +209,18 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB, ulong stateC)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
             unchecked
             {
-                ulong fa = stateA;
-                stateA = 15241094284759029579UL * _c;
+                ulong fa = StateA;
+                StateA = 15241094284759029579UL * _c;
                 _c -= _b;
                 _b -= fa;
                 _b.RotateLeftInPlace(12);
@@ -228,20 +229,30 @@ namespace ShaiRandom
             }
         }
 
-        public override IEnhancedRandom Copy() => new RomuTrioRandom(stateA, stateB, stateC);
-        public override string StringSerialize() => $"#RTrR`{stateA:X}~{stateB:X}~{stateC:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new RomuTrioRandom(StateA, StateB, StateC);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#RTrR`{StateA:X}~{StateB:X}~{StateC:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as RomuTrioRandom);
-        public bool Equals(RomuTrioRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB && stateC == other.stateC;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB, stateC);
+
+        /// <inheritdoc />
+        public bool Equals(RomuTrioRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC);
 
         public static bool operator ==(RomuTrioRandom? left, RomuTrioRandom? right) => EqualityComparer<RomuTrioRandom>.Default.Equals(left, right);
         public static bool operator !=(RomuTrioRandom? left, RomuTrioRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -22,20 +22,20 @@ namespace ShaiRandom
         /**
          * The first state; can be any long except 0.
          */
-        public ulong stateA { get => _a; set => _a = value == 0UL ? 0xD3833E804F4C574BUL : value; }
+        public ulong StateA { get => _a; set => _a = value == 0UL ? 0xD3833E804F4C574BUL : value; }
         /**
          * The second state; can be any long except 0.
          */
-        public ulong stateB { get => _b; set => _b = value == 0UL ? 0x790B300BF9FE738FUL : value; }
+        public ulong StateB { get => _b; set => _b = value == 0UL ? 0x790B300BF9FE738FUL : value; }
         /**
          * The third state; can be any long. If this has just been set to some value, then the next call to
          * {@link #nextLong()} will return that value as-is. Later calls will be more random.
          */
-        public ulong stateC { get; set; }
+        public ulong StateC { get; set; }
         /**
          * The fourth state; can be any long.
          */
-        public ulong stateD { get; set; }
+        public ulong StateD { get; set; }
 
         public static ulong Jump(ulong state)
         {
@@ -57,10 +57,10 @@ namespace ShaiRandom
          */
         public StrangerRandom()
         {
-            stateA = MakeSeed();
+            StateA = MakeSeed();
             _b = Jump(_a);
-            stateC = MakeSeed();
-            stateD = MakeSeed();
+            StateC = MakeSeed();
+            StateD = MakeSeed();
         }
 
         /**
@@ -96,10 +96,10 @@ namespace ShaiRandom
          */
         public StrangerRandom(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
+            StateD = stateD;
         }
 
         /// <summary>
@@ -133,13 +133,13 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    return stateA;
+                    return StateA;
                 case 1:
-                    return stateB;
+                    return StateB;
                 case 2:
-                    return stateC;
+                    return StateC;
                 default:
-                    return stateD;
+                    return StateD;
             }
         }
 
@@ -155,16 +155,16 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    stateA = value;
+                    StateA = value;
                     break;
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 case 2:
-                    stateC = value;
+                    StateC = value;
                     break;
                 default:
-                    stateD = value;
+                    StateD = value;
                     break;
             }
         }
@@ -178,11 +178,11 @@ namespace ShaiRandom
          */
         public override void Seed(ulong seed)
         {
-            stateA = seed ^ 0xFA346CBFD5890825UL;
-            if (stateA == 0UL) stateA = 0xD3833E804F4C574BUL;
+            StateA = seed ^ 0xFA346CBFD5890825UL;
+            if (StateA == 0UL) StateA = 0xD3833E804F4C574BUL;
             _b = Jump(_a);
-            stateC = Jump(_b - seed);
-            stateD = Jump(stateC + 0xC6BC279692B5C323UL);
+            StateC = Jump(_b - seed);
+            StateD = Jump(StateC + 0xC6BC279692B5C323UL);
         }
 
         /**
@@ -199,10 +199,10 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
+            StateD = stateD;
         }
         /// <summary>
         /// Sets the A and B states in this using the giveb stateA, and sets states C and D to stateC and stateD verbatim.
@@ -213,43 +213,53 @@ namespace ShaiRandom
         /// <param name="stateD">Can be any ulong.</param>
         public override void SetState(ulong stateA, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
+            StateA = stateA;
             _b = Jump(_a);
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateC = stateC;
+            StateD = stateD;
         }
 
         public override ulong NextULong()
         {
             ulong fa = _a;
             ulong fb = _b;
-            ulong fc = stateC;
-            ulong fd = stateD;
+            ulong fc = StateC;
+            ulong fd = StateD;
             unchecked
             {
                 _a = fb ^ fb << 7;
                 _b = fa ^ fa >> 9;
-                stateC = fd.RotateLeft(39) - fb;
-                stateD = fa - fc + 0xC6BC279692B5C323UL;
+                StateC = fd.RotateLeft(39) - fb;
+                StateD = fa - fc + 0xC6BC279692B5C323UL;
                 return fc;
             }
         }
 
-        public override IEnhancedRandom Copy() => new StrangerRandom(stateA, stateB, stateC, stateD);
-        public override string StringSerialize() => $"#StrR`{stateA:X}~{stateB:X}~{stateC:X}~{stateD:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new StrangerRandom(StateA, StateB, StateC, StateD);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#StrR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as StrangerRandom);
-        public bool Equals(StrangerRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB && stateC == other.stateC && stateD == other.stateD;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB, stateC, stateD);
+
+        /// <inheritdoc />
+        public bool Equals(StrangerRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC && StateD == other.StateD;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC, StateD);
 
         public static bool operator ==(StrangerRandom? left, StrangerRandom? right) => EqualityComparer<StrangerRandom>.Default.Equals(left, right);
         public static bool operator !=(StrangerRandom? left, StrangerRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 4 states, more here later. This one has a good guaranteed minimum period, (2 to the 65) - 2.

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 3 states, more here later.

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -22,24 +22,24 @@ namespace ShaiRandom
          * The first state; can be any long. If this has just been set to some value, then the next call to
          * {@link #nextLong()} will return that value as-is. Later calls will be more random.
          */
-        public ulong stateA { get; set; }
+        public ulong StateA { get; set; }
         /**
          * The second state; can be any long.
          */
-        public ulong stateB { get; set; }
+        public ulong StateB { get; set; }
         /**
          * The third state; can be any long.
          */
-        public ulong stateC { get; set; }
+        public ulong StateC { get; set; }
 
         /**
          * Creates a new TricycleRandom with a random state.
          */
         public TricycleRandom()
         {
-            stateA = MakeSeed();
-            stateB = MakeSeed();
-            stateC = MakeSeed();
+            StateA = MakeSeed();
+            StateB = MakeSeed();
+            StateC = MakeSeed();
         }
 
         /**
@@ -61,9 +61,9 @@ namespace ShaiRandom
          */
         public TricycleRandom(ulong stateA, ulong stateB, ulong stateC)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
         }
 
         /// <summary>
@@ -97,11 +97,11 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    return stateA;
+                    return StateA;
                 case 1:
-                    return stateB;
+                    return StateB;
                 default:
-                    return stateC;
+                    return StateC;
             }
         }
 
@@ -117,13 +117,13 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    stateA = value;
+                    StateA = value;
                     break;
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 default:
-                    stateC = value;
+                    StateC = value;
                     break;
             }
         }
@@ -144,19 +144,19 @@ namespace ShaiRandom
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateA = x ^ x >> 27;
+                StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateB = x ^ x >> 27;
+                StateB = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateC = x ^ x >> 27;
+                StateC = x ^ x >> 27;
             }
         }
 
@@ -173,51 +173,63 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB, ulong stateC)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
+            this.StateA = stateA;
+            this.StateB = stateB;
+            this.StateC = stateC;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
-            ulong fa = stateA;
-            ulong fb = stateB;
-            ulong fc = stateC;
+            ulong fa = StateA;
+            ulong fb = StateB;
+            ulong fc = StateC;
             unchecked
             {
-                stateA = 0xD1342543DE82EF95UL * fc;
-                stateB = fa ^ fb ^ fc;
-                stateC = fb.RotateLeft(41) + 0xC6BC279692B5C323UL;
+                StateA = 0xD1342543DE82EF95UL * fc;
+                StateB = fa ^ fb ^ fc;
+                StateC = fb.RotateLeft(41) + 0xC6BC279692B5C323UL;
             }
             return fa;
         }
 
+        /// <inheritdoc />
         public override ulong PreviousULong()
         {
-            ulong fa = stateA;
-            ulong fb = stateB;
-            ulong fc = stateC;
+            ulong fa = StateA;
+            ulong fb = StateB;
+            ulong fc = StateC;
 
-            stateC = 0x572B5EE77A54E3BDUL * fa;
-            stateB = BitExtensions.RotateRight(fc - 0xC6BC279692B5C323UL, 41);
-            stateA = fb ^ stateB ^ stateC;
-            return stateB ^ 0x572B5EE77A54E3BDUL * stateA ^ BitExtensions.RotateRight(stateC - 0xC6BC279692B5C323UL, 41);
+            StateC = 0x572B5EE77A54E3BDUL * fa;
+            StateB = BitExtensions.RotateRight(fc - 0xC6BC279692B5C323UL, 41);
+            StateA = fb ^ StateB ^ StateC;
+            return StateB ^ 0x572B5EE77A54E3BDUL * StateA ^ BitExtensions.RotateRight(StateC - 0xC6BC279692B5C323UL, 41);
         }
 
-        public override IEnhancedRandom Copy() => new TricycleRandom(stateA, stateB, stateC);
-        public override string StringSerialize() => $"#TriR`{stateA:X}~{stateB:X}~{stateC:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new TricycleRandom(StateA, StateB, StateC);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#TriR`{StateA:X}~{StateB:X}~{StateC:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as TricycleRandom);
-        public bool Equals(TricycleRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB && stateC == other.stateC;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB, stateC);
+
+        /// <inheritdoc />
+        public bool Equals(TricycleRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC);
 
         public static bool operator ==(TricycleRandom? left, TricycleRandom? right) => EqualityComparer<TricycleRandom>.Default.Equals(left, right);
         public static bool operator !=(TricycleRandom? left, TricycleRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace ShaiRandom
+namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 4 states, implementing a known-rather-good algorithm, more here later.

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -21,27 +21,27 @@ namespace ShaiRandom
         /**
          * The first state; can be any long except that the whole state must not all be 0.
          */
-        public ulong stateA { get; set; }
+        public ulong StateA { get; set; }
         /**
          * The second state; can be any long except that the whole state must not all be 0.
          * This is the state that is scrambled and returned; if it is 0 before a number
          * is generated, then the next number will be 0.
          */
-        public ulong stateB { get; set; }
+        public ulong StateB { get; set; }
         /**
          * The third state; can be any long except that the whole state must not all be 0.
          */
-        public ulong stateC { get; set; }
+        public ulong StateC { get; set; }
         private ulong _d;
         /**
          * The fourth state; can be any long except that the whole state must not all be 0.
          * If all other states are 0, and this would be set to 0,
          * then this is instead set to 0xFFFFFFFFFFFFFFFFUL.
          */
-        public ulong stateD
+        public ulong StateD
         {
             get => _d;
-            set => _d = (stateA | stateB | stateC | value) == 0UL ? 0xFFFFFFFFFFFFFFFFUL : value;
+            set => _d = (StateA | StateB | StateC | value) == 0UL ? 0xFFFFFFFFFFFFFFFFUL : value;
         }
 
 
@@ -50,10 +50,10 @@ namespace ShaiRandom
          */
         public Xoshiro256StarStarRandom()
         {
-            stateA = MakeSeed();
-            stateB = MakeSeed();
-            stateC = MakeSeed();
-            stateD = MakeSeed();
+            StateA = MakeSeed();
+            StateB = MakeSeed();
+            StateC = MakeSeed();
+            StateD = MakeSeed();
         }
 
         /**
@@ -76,10 +76,10 @@ namespace ShaiRandom
          */
         public Xoshiro256StarStarRandom(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
+            StateD = stateD;
         }
 
         /// <summary>
@@ -113,13 +113,13 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    return stateA;
+                    return StateA;
                 case 1:
-                    return stateB;
+                    return StateB;
                 case 2:
-                    return stateC;
+                    return StateC;
                 default:
-                    return stateD;
+                    return StateD;
             }
         }
 
@@ -135,16 +135,16 @@ namespace ShaiRandom
             switch (selection)
             {
                 case 0:
-                    stateA = value;
+                    StateA = value;
                     break;
                 case 1:
-                    stateB = value;
+                    StateB = value;
                     break;
                 case 2:
-                    stateC = value;
+                    StateC = value;
                     break;
                 default:
-                    stateD = value;
+                    StateD = value;
                     break;
             }
         }
@@ -165,19 +165,19 @@ namespace ShaiRandom
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateA = x ^ x >> 27;
+                StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateB = x ^ x >> 27;
+                StateB = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                stateC = x ^ x >> 27;
+                StateC = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
@@ -201,43 +201,54 @@ namespace ShaiRandom
          */
         public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
         {
-            this.stateA = stateA;
-            this.stateB = stateB;
-            this.stateC = stateC;
-            this.stateD = stateD;
+            StateA = stateA;
+            StateB = stateB;
+            StateC = stateC;
+            StateD = stateD;
         }
 
+        /// <inheritdoc />
         public override ulong NextULong()
         {
             unchecked
             {
-                ulong result = BitExtensions.RotateLeft(stateB * 5UL, 7) * 9UL;
-                ulong t = stateB << 17;
-                stateC ^= stateA;
-                _d ^= stateB;
-                stateB ^= stateC;
-                stateA ^= _d;
-                stateC ^= t;
+                ulong result = (StateB * 5UL).RotateLeft(7) * 9UL;
+                ulong t = StateB << 17;
+                StateC ^= StateA;
+                _d ^= StateB;
+                StateB ^= StateC;
+                StateA ^= _d;
+                StateC ^= t;
                 _d.RotateLeftInPlace(45);
                 return result;
             }
         }
 
-        public override IEnhancedRandom Copy() => new Xoshiro256StarStarRandom(stateA, stateB, stateC, stateD);
-        public override string StringSerialize() => $"#XSSR`{stateA:X}~{stateB:X}~{stateC:X}~{stateD:X}`";
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new Xoshiro256StarStarRandom(StateA, StateB, StateC, StateD);
+
+        /// <inheritdoc />
+        public override string StringSerialize() => $"#XSSR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             int idx = data.IndexOf('`');
-            stateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            stateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
+            StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
 
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as Xoshiro256StarStarRandom);
-        public bool Equals(Xoshiro256StarStarRandom? other) => other != null && stateA == other.stateA && stateB == other.stateB && stateC == other.stateC && stateD == other.stateD;
-        public override int GetHashCode() => HashCode.Combine(stateA, stateB, stateC, _d);
+
+        /// <inheritdoc />
+        public bool Equals(Xoshiro256StarStarRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC && StateD == other.StateD;
+
+        /// <inheritdoc />
+        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC, _d);
 
         public static bool operator ==(Xoshiro256StarStarRandom? left, Xoshiro256StarStarRandom? right) => EqualityComparer<Xoshiro256StarStarRandom>.Default.Equals(left, right);
         public static bool operator !=(Xoshiro256StarStarRandom? left, Xoshiro256StarStarRandom? right) => !(left == right);

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -40,29 +40,60 @@ namespace ShaiRandom
             Wrapped = wrapping;
         }
 
+        /// <summary>
+        /// The <see cref="IEnhancedRandom.StateCount"/> of the wrapped generator.
+        /// </summary>
         public override int StateCount => Wrapped.StateCount;
 
+        /// <summary>
+        /// The <see cref="IEnhancedRandom.SupportsReadAccess"/> value of the wrapped generator.
+        /// </summary>
         public override bool SupportsReadAccess => Wrapped.SupportsReadAccess;
 
+        /// <summary>
+        /// The <see cref="IEnhancedRandom.SupportsWriteAccess"/> value of the wrapped generator.
+        /// </summary>
         public override bool SupportsWriteAccess => Wrapped.SupportsWriteAccess;
 
+        /// <summary>
+        /// The <see cref="IEnhancedRandom.SupportsSkip"/> value of the wrapped generator.
+        /// </summary>
         public override bool SupportsSkip => Wrapped.SupportsSkip;
 
+        /// <summary>
+        /// The <see cref="IEnhancedRandom.SupportsPrevious"/> value of the wrapped generator.
+        /// </summary>
         public override bool SupportsPrevious => Wrapped.SupportsPrevious;
 
+        /// <inheritdoc />
         public override IEnhancedRandom Copy() => new ReversingWrapper(Wrapped.Copy());
+
+        /// <inheritdoc />
         public override ulong NextULong() => Wrapped.PreviousULong();
 
+        /// <inheritdoc />
         public override void Seed(ulong seed) => Wrapped.Seed(seed);
+
+        /// <inheritdoc />
         public override string StringSerialize() => "R" + Wrapped.StringSerialize().Substring(1);
+
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             Wrapped.StringDeserialize(data);
             return this;
         }
+
+        /// <inheritdoc />
         public override ulong Skip(ulong distance) => Wrapped.Skip(0UL - distance);
+
+        /// <inheritdoc />
         public override ulong PreviousULong() => Wrapped.NextULong();
+
+        /// <inheritdoc />
         public override bool Equals(object? obj) => Equals(obj as ReversingWrapper);
+
+        /// <inheritdoc />
         public bool Equals(ReversingWrapper? other) => other != null && EqualityComparer<IEnhancedRandom>.Default.Equals(Wrapped, other.Wrapped);
 
         public static bool operator ==(ReversingWrapper? left, ReversingWrapper? right) => EqualityComparer<ReversingWrapper>.Default.Equals(left, right);

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -1,7 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using ShaiRandom.Generators;
 
-namespace ShaiRandom
+namespace ShaiRandom.Wrappers
 {
 
     /// <summary>

--- a/ShaiRandom/Wrappers/TRWrapper.cs
+++ b/ShaiRandom/Wrappers/TRWrapper.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using ShaiRandom.Generators;
 using Troschuetz.Random;
 
-namespace ShaiRandom
+namespace ShaiRandom.Wrappers
 {
     /// <summary>
     /// Wraps a ShaiRandom AbstractRandom object so it can also be used as a Troschuetz.Random IGenerator.


### PR DESCRIPTION
- Added `inheritdoc` tags wherever they looked reasonable
    - I know there is some documentation reformatting in progress, particularly with the `EnhancedRandom.cs` file.  As such, whenever I encountered documentation between `AbstractRandom` and `IEnhancedRandom` that differed, I tried to leave it alone in order to not interfere with anything.  In particular, I tried to leave the documentation in place where it appeared the `AbstractRandom` documentation was describing an implementation detail that might not apply to all interface implementations.  Please feel free to let me know if any of the `inheritdoc` tags are misplaced and I can revert them
- Miscellaneous code cleanup with default arguments and some convenient C# syntax (mostly just things there was a convenient refactor option for)
- Modified namespaces to match folder structure
    - I think this should fall in line better with Troschuetz conventions, as well as general C# conventions.
- Renamed some properties and functions to match C# naming conventions (mostly `state` fields)