### PR TITLE
Integrated Distributions More Closely With Troschuetz

### DIFF
--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -120,7 +120,7 @@ namespace ShaiRandom.UnitTests
         [Fact]
         public void TRWrapperSerDeserTest()
         {
-            TRWrapper random = new TRWrapper(new FourWheelRandom(123456789UL, 0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL));
+            TRGeneratorWrapper random = new TRGeneratorWrapper(new FourWheelRandom(123456789UL, 0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL));
             random.NextULong();
             string data = random.StringSerialize();
             Assert.StartsWith("TFoWR`", data);

--- a/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
@@ -42,7 +42,7 @@ namespace ShaiRandom.Distributions.Continuous
     ///   <para>The thread safety of this class depends on the one of the underlying generator.</para>
     /// </remarks>
     [Serializable]
-    public sealed class ExponentialDistribution : IContinuousDistribution
+    public sealed class ExponentialDistribution : IEnhancedContinuousDistribution
     {
         #region Constants
 

--- a/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
@@ -42,7 +42,7 @@ namespace ShaiRandom.Distributions.Continuous
     ///   <para>The thread safety of this class depends on the one of the underlying generator.</para>
     /// </remarks>
     [Serializable]
-    public sealed class KumaraswamyDistribution : IContinuousDistribution
+    public sealed class KumaraswamyDistribution : IEnhancedContinuousDistribution
     {
         #region Constants
 

--- a/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
@@ -43,7 +43,7 @@ namespace ShaiRandom.Distributions.Continuous
     ///   <para>The thread safety of this class depends on the one of the underlying generator.</para>
     /// </remarks>
     [Serializable]
-    public sealed class NormalDistribution : IContinuousDistribution
+    public sealed class NormalDistribution : IEnhancedContinuousDistribution
     {
         #region Constants
 

--- a/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
@@ -44,7 +44,7 @@ namespace ShaiRandom.Distributions.Continuous
     ///   <para>The thread safety of this class depends on the one of the underlying generator.</para>
     /// </remarks>
     [Serializable]
-    public sealed class TriangularDistribution : IContinuousDistribution
+    public sealed class TriangularDistribution : IEnhancedContinuousDistribution
     {
         #region Constants
 

--- a/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
@@ -42,7 +42,7 @@ namespace ShaiRandom.Distributions.Discrete
     ///   <para>The thread safety of this class depends on the one of the underlying generator.</para>
     /// </remarks>
     [Serializable]
-    public sealed class BinomialDistribution : IDiscreteDistribution
+    public sealed class BinomialDistribution : IEnhancedDiscreteDistribution
     {
         #region Constants
 

--- a/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
@@ -42,7 +42,7 @@ namespace ShaiRandom.Distributions.Discrete
     ///   <para>The thread safety of this class depends on the one of the underlying generator.</para>
     /// </remarks>
     [Serializable]
-    public sealed class PoissonDistribution : IDiscreteDistribution
+    public sealed class PoissonDistribution : IEnhancedDiscreteDistribution
     {
         #region Constants
 

--- a/ShaiRandom/Distributions/IEnhancedDistribution.cs
+++ b/ShaiRandom/Distributions/IEnhancedDistribution.cs
@@ -1,19 +1,19 @@
 ﻿/*
  * MIT License
- * 
+ *
  * Copyright (c) 2006-2007 Stefan Troschuetz <stefan@troschuetz.de>
  * Copyright (c) 2012-2021 Alessio Parma <alessio.parma@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,14 +30,14 @@ namespace ShaiRandom.Distributions
     /// <summary>
     ///   Declares common functionality for all continuous random number distributions.
     /// </summary>
-    public interface IContinuousDistribution : IDistribution
+    public interface IEnhancedContinuousDistribution : IEnhancedDistribution
     {
     }
 
     /// <summary>
     ///   Declares common functionality for all discrete random number distributions.
     /// </summary>
-    public interface IDiscreteDistribution : IDistribution
+    public interface IEnhancedDiscreteDistribution : IEnhancedDistribution
     {
         /// <summary>
         ///   Returns a distributed random number.
@@ -49,7 +49,7 @@ namespace ShaiRandom.Distributions
     /// <summary>
     ///   Declares common functionality for all random number distributions.
     /// </summary>
-    public interface IDistribution
+    public interface IEnhancedDistribution
     {
         /// <summary>
         ///   Gets the <see cref="IEnhancedRandom"/> object that is used as underlying random number generator.

--- a/ShaiRandom/EnhancedRandom.cs
+++ b/ShaiRandom/EnhancedRandom.cs
@@ -996,7 +996,7 @@ namespace ShaiRandom
         /// <summary>
         /// Given a string produced by <see cref="StringSerialize()"/> on any valid subclass of AbstractRandom,
         /// this returns a new IEnhancedRandom with the same implementation and state it had when it was serialized.
-        /// This handles all AbstractRandom implementations in this library, including <see cref="TRWrapper"/> and
+        /// This handles all AbstractRandom implementations in this library, including <see cref="TRGeneratorWrapper"/> and
         /// <see cref="ReversingWrapper"/> (both of which it currently handles with a special case).
         /// </summary>
         /// <param name="data">A string produced by an AbstractRandom's StringSerialize() method.</param>
@@ -1004,7 +1004,7 @@ namespace ShaiRandom
         public static IEnhancedRandom Deserialize(string data)
         {
             if (data.StartsWith('T'))
-                return new TRWrapper(TAGS[data.Substring(1, 4)].Copy().StringDeserialize(data));
+                return new TRGeneratorWrapper(TAGS[data.Substring(1, 4)].Copy().StringDeserialize(data));
             if (data.StartsWith('R'))
                 return new ReversingWrapper(TAGS[data.Substring(1, 4)].Copy().StringDeserialize(data));
             return TAGS[data.Substring(1, 4)].Copy().StringDeserialize(data);

--- a/ShaiRandom/Wrappers/TRContinuousDistributionWrapper.cs
+++ b/ShaiRandom/Wrappers/TRContinuousDistributionWrapper.cs
@@ -1,0 +1,29 @@
+﻿using ShaiRandom.Distributions;
+using Troschuetz.Random;
+
+namespace ShaiRandom.Wrappers
+{
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedContinuousDistribution object so it can also be used as a Troschuetz.Random IContinuousDistribution.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IContinuousDistribution and IEnhancedContinuousDistribution.  Any IEnhancedDistribution member is
+    /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all IDistribution methods are
+    /// explicitly implemented and are implemented in terms of IEnhancedDistribution methods.
+    /// </remarks>
+    public class TRContinuousDistributionWrapper : TRDistributionWrapper, IContinuousDistribution, IEnhancedContinuousDistribution
+    {
+        /// <summary>
+        /// The ShaiRandom distribution being wrapped.
+        /// </summary>
+        public new IEnhancedContinuousDistribution Wrapped => (IEnhancedContinuousDistribution)base.Wrapped;
+
+        /// <summary>
+        /// Creates a new wrapper which wraps the given ShaiRandom distribution.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
+        public TRContinuousDistributionWrapper(IEnhancedContinuousDistribution wrapped)
+            : base(wrapped)
+        { }
+    }
+}

--- a/ShaiRandom/Wrappers/TRDiscreteDistributionWrapper.cs
+++ b/ShaiRandom/Wrappers/TRDiscreteDistributionWrapper.cs
@@ -1,0 +1,36 @@
+﻿using ShaiRandom.Distributions;
+using Troschuetz.Random;
+
+namespace ShaiRandom.Wrappers
+{
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedDiscreteDistribution object so it can also be used as a Troschuetz.Random IDiscreteDistribution.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IDiscreteDistribution and IEnhancedDiscreteDistribution.  Any ShaiRandom distribution member is
+    /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all Troschuetz methods are
+    /// explicitly implemented and are implemented in terms of ShaiRandom distribution methods.
+    /// </remarks>
+    public class TRDiscreteDistributionWrapper : TRDistributionWrapper, IDiscreteDistribution, IEnhancedDiscreteDistribution
+    {
+        /// <summary>
+        /// The ShaiRandom distribution being wrapped.
+        /// </summary>
+        public new IEnhancedDiscreteDistribution Wrapped => (IEnhancedDiscreteDistribution)base.Wrapped;
+
+        /// <summary>
+        /// Creates a new wrapper which wraps the given ShaiRandom distribution.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
+        public TRDiscreteDistributionWrapper(IEnhancedDiscreteDistribution wrapped)
+            : base(wrapped)
+        { }
+
+        /// <inheritdoc />
+        public int NextInt() => Wrapped.NextInt();
+
+        #region IDiscreteDistribution Explicit Implementation
+        int IDiscreteDistribution.Next() => NextInt();
+        #endregion
+    }
+}

--- a/ShaiRandom/Wrappers/TRDistributionWrapper.cs
+++ b/ShaiRandom/Wrappers/TRDistributionWrapper.cs
@@ -1,0 +1,79 @@
+﻿using ShaiRandom.Distributions;
+using Troschuetz.Random;
+
+namespace ShaiRandom.Wrappers
+{
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedDistribution object so it can also be used as a Troschuetz.Random IDistribution.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IDistribution and IEnhancedDistribution.  Any IEnhancedDistribution member is
+    /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all IDistribution methods are
+    /// explicitly implemented and are implemented in terms of IEnhancedDistribution methods.
+    /// </remarks>
+    public class TRDistributionWrapper : IDistribution, IEnhancedDistribution
+    {
+        /// <summary>
+        /// The ShaiRandom distribution being wrapped.
+        /// </summary>
+        public IEnhancedDistribution Wrapped { get; }
+
+        /// <summary>
+        /// Creates a new wrapper which wraps the given ShaiRandom distribution.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
+        public TRDistributionWrapper(IEnhancedDistribution wrapped) => Wrapped = wrapped;
+
+        /// <inheritdoc />
+        public IEnhancedRandom Generator => Wrapped.Generator;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Maximum" />
+        public double Maximum => Wrapped.Maximum;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Mean" />
+        public double Mean => Wrapped.Mean;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Median" />
+        public double Median => Wrapped.Median;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Minimum" />
+        public double Minimum => Wrapped.Minimum;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Mode" />
+        public double[] Mode => Wrapped.Mode;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Variance" />
+        public double Variance => Wrapped.Variance;
+
+        /// <inheritdoc cref="IEnhancedDistribution.NextDouble" />
+        public double NextDouble() => Wrapped.NextDouble();
+
+        /// <inheritdoc />
+        public int Steps => Wrapped.Steps;
+
+        /// <inheritdoc />
+        public int ParameterCount => Wrapped.ParameterCount;
+
+        /// <inheritdoc />
+        public string ParameterName(int index) => Wrapped.ParameterName(index);
+
+        /// <inheritdoc />
+        public double ParameterValue(int index) => Wrapped.ParameterValue(index);
+
+        /// <inheritdoc />
+        public void SetParameterValue(int index, double value) => Wrapped.SetParameterValue(index, value);
+
+        #region IDistribution Explicit Implementations
+
+        bool IDistribution.CanReset => false;
+        bool IDistribution.Reset() => false;
+
+        IGenerator IDistribution.Generator => Wrapped.Generator switch
+        {
+            IGenerator trGen => trGen,
+            _ => new TRGeneratorWrapper(Wrapped.Generator)
+        };
+
+        #endregion
+    }
+}

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -6,10 +6,15 @@ using Troschuetz.Random;
 namespace ShaiRandom.Wrappers
 {
     /// <summary>
-    /// Wraps a ShaiRandom AbstractRandom object so it can also be used as a Troschuetz.Random IGenerator.
+    /// Wraps a ShaiRandom IEnhancedRandom object so it can also be used as a Troschuetz.Random IGenerator.
     /// </summary>
+    /// <remarks>
+    /// This class implements both IGenerator and IEnhancedRandom.  Any IEnhancedRandom member is implemented by
+    /// simply forwarding to the ShaiRandom generator being wrapped;  all IGenerator methods are explicitly implemented
+    /// and are implemented in terms of IEnhancedRandom methods.
+    /// </remarks>
     [System.Serializable]
-    public class TRWrapper : AbstractRandom, IGenerator, IEquatable<TRWrapper?>
+    public class TRGeneratorWrapper : AbstractRandom, IGenerator, IEquatable<TRGeneratorWrapper?>
     {
         /// <summary>
         /// The identifying tag here is "T" , which is an invalid length to indicate the tag is not meant to be registered or used on its own.
@@ -21,31 +26,61 @@ namespace ShaiRandom.Wrappers
         /// </summary>
         public IEnhancedRandom Wrapped { get; set; }
 
-        public TRWrapper() => Wrapped = new FourWheelRandom();
+        /// <summary>
+        /// Creates a wrapper around a new FourWheelRandom generator with a random state.
+        /// </summary>
+        public TRGeneratorWrapper() => Wrapped = new FourWheelRandom();
 
-        public TRWrapper(ulong seed) => Wrapped = new FourWheelRandom(seed);
+        /// <summary>
+        /// Creates a wrapper around a new FourWheelRandom generator, whose state will be initialized with the given seed.
+        /// </summary>
+        /// <param name="seed">Seed to initialize the new generator with.</param>
+        public TRGeneratorWrapper(ulong seed) => Wrapped = new FourWheelRandom(seed);
 
-        public TRWrapper(IEnhancedRandom wrapped) => Wrapped = wrapped;
+        /// <summary>
+        /// Creates a wrapper around the given ShaiRandom generator.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom generator to wrap.</param>
+        public TRGeneratorWrapper(IEnhancedRandom wrapped) => Wrapped = wrapped;
 
+        /// <inheritdoc />
         public override int StateCount => Wrapped.StateCount;
+        /// <inheritdoc />
         public override bool SupportsReadAccess => Wrapped.SupportsReadAccess;
+        /// <inheritdoc />
         public override bool SupportsWriteAccess => Wrapped.SupportsWriteAccess;
+        /// <inheritdoc />
         public override bool SupportsSkip => Wrapped.SupportsSkip;
+        /// <inheritdoc />
         public override bool SupportsPrevious => Wrapped.SupportsPrevious;
 
-        public override IEnhancedRandom Copy() => new TRWrapper(Wrapped.Copy());
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new TRGeneratorWrapper(Wrapped.Copy());
+        /// <inheritdoc />
         public override double NextDouble() => Wrapped.NextDouble();
+        /// <inheritdoc />
         public override ulong NextULong() => Wrapped.NextULong();
+        /// <inheritdoc />
         public override ulong SelectState(int selection) => Wrapped.SelectState(selection);
+        /// <inheritdoc />
         public override void Seed(ulong seed) => Wrapped.Seed(seed);
+        /// <inheritdoc />
         public override void SetState(ulong stateA) => Wrapped.SetState(stateA);
+        /// <inheritdoc />
         public override void SetState(ulong stateA, ulong stateB) => Wrapped.SetState(stateA, stateB);
+        /// <inheritdoc />
         public override void SetState(ulong stateA, ulong stateB, ulong stateC) => Wrapped.SetState(stateA, stateB, stateC);
+        /// <inheritdoc />
         public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Wrapped.SetState(stateA, stateB, stateC, stateD);
+        /// <inheritdoc />
         public override void SetState(params ulong[] states) => Wrapped.SetState(states);
+        /// <inheritdoc />
         public override ulong Skip(ulong distance) => Wrapped.Skip(distance);
+        /// <inheritdoc />
         public override ulong PreviousULong() => Wrapped.PreviousULong();
+        /// <inheritdoc />
         public override string StringSerialize() => "T"+ Wrapped.StringSerialize().Substring(1);
+        /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(string data)
         {
             Wrapped.StringDeserialize(data);
@@ -73,11 +108,13 @@ namespace ShaiRandom.Wrappers
         bool IGenerator.Reset(uint seed) => false;
         #endregion
 
-        public override bool Equals(object? obj) => Equals(obj as TRWrapper);
-        public bool Equals(TRWrapper? other) => other != null && EqualityComparer<IEnhancedRandom>.Default.Equals(Wrapped, other.Wrapped);
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => Equals(obj as TRGeneratorWrapper);
+        /// <inheritdoc />
+        public bool Equals(TRGeneratorWrapper? other) => other != null && EqualityComparer<IEnhancedRandom>.Default.Equals(Wrapped, other.Wrapped);
 
-        public static bool operator ==(TRWrapper? left, TRWrapper? right) => EqualityComparer<TRWrapper>.Default.Equals(left, right);
-        public static bool operator !=(TRWrapper? left, TRWrapper? right) => !(left == right);
+        public static bool operator ==(TRGeneratorWrapper? left, TRGeneratorWrapper? right) => EqualityComparer<TRGeneratorWrapper>.Default.Equals(left, right);
+        public static bool operator !=(TRGeneratorWrapper? left, TRGeneratorWrapper? right) => !(left == right);
 
 
     }


### PR DESCRIPTION
# Changes
- `IDistribution` renamed to `IEnhancedDistribution`
- `IDiscreteDistribution` renamed to `IEnhancedDiscreteDistribution`
- `IContinuousDistribution` renamed to `IEnhancedContinuousDistribution`
- `TRWrapper` renamed to `TRGeneratorWrapper` to distinguish it from the new wrappers
- Created `TRDistributionWrapper`
    - Allows an `IEnhancedDistribution` to be wrapped and used as a Troschuetz `IDistribution`
    - Basically like `TRGeneratorWrapper` but for distributions
- Created `TRDiscreteDistributionWrapper` and `TRContinuousDistributionWrapper`
    - Same as `TRDistributionWrapper`, but they wrap `IEnhancedDiscreteDistribution` into Troschetz `IDiscreteDistribution`, and `IEnhancedContinuousDistribution` into `IContinuousDistribution`, respectively
- Added documentation to `TRGeneratorWrapper` where what it should state was simple and obvious.

# End State/Goal
The goal here is simply to enable cleaner interop with Troschuetz types in a consistent way.  Although the actual concrete distributions are implemented differently, ShaiRandom's distribution interfaces are quite similar to the ones in Troschuetz, so it seems useful to be able to use them as Troschuetz distributions.