### PR TITLE
Fixed KnownSeriesRandom Bugs and Warnings

### DIFF
--- a/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/ExponentialDistribution.cs
@@ -28,7 +28,6 @@ using ShaiRandom.Generators;
 namespace ShaiRandom.Distributions.Continuous
 {
     using System;
-    using ShaiRandom;
 
     /// <summary>
     ///   Provides generation of exponential distributed random numbers.

--- a/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
@@ -28,7 +28,6 @@ using ShaiRandom.Generators;
 namespace ShaiRandom.Distributions.Continuous
 {
     using System;
-    using ShaiRandom;
 
     /// <summary>
     ///   Provides generation of Kumaraswamy distributed random numbers.

--- a/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/NormalDistribution.cs
@@ -28,7 +28,6 @@ using ShaiRandom.Generators;
 namespace ShaiRandom.Distributions.Continuous
 {
     using System;
-    using ShaiRandom;
 
     /// <summary>
     ///   Provides generation of normal distributed random numbers.

--- a/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/TriangularDistribution.cs
@@ -28,7 +28,6 @@ using ShaiRandom.Generators;
 namespace ShaiRandom.Distributions.Continuous
 {
     using System;
-    using ShaiRandom;
 
     /// <summary>
     ///   Provides generation of normal distributed random numbers.

--- a/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/BinomialDistribution.cs
@@ -28,7 +28,6 @@ using ShaiRandom.Generators;
 namespace ShaiRandom.Distributions.Discrete
 {
     using System;
-    using ShaiRandom;
 
     /// <summary>
     ///   Provides generation of Binomial distributed random numbers.

--- a/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/PoissonDistribution.cs
@@ -28,7 +28,6 @@ using ShaiRandom.Generators;
 namespace ShaiRandom.Distributions.Discrete
 {
     using System;
-    using ShaiRandom;
 
     /// <summary>
     ///   Provides generation of Poisson distributed random numbers.

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using ShaiRandom.Wrappers;
 
 namespace ShaiRandom.Generators
@@ -133,80 +134,19 @@ namespace ShaiRandom.Generators
         }
 
         /// <inheritdoc />
-        public virtual void SetState(ulong state)
-        {
-            for (int i = StateCount - 1; i >= 0; i--)
-            {
-                SetSelectedState(i, state);
-            }
-        }
+        public virtual void SetState(ulong state) => ((IEnhancedRandom)this).SetState(state);
 
         /// <inheritdoc />
-        public virtual void SetState(ulong stateA, ulong stateB)
-        {
-            int c = StateCount;
-            for (int i = 0; i < c; i += 2)
-            {
-                SetSelectedState(i, stateA);
-            }
-            for (int i = 1; i < c; i += 2)
-            {
-                SetSelectedState(i, stateB);
-            }
-        }
+        public virtual void SetState(ulong stateA, ulong stateB) => ((IEnhancedRandom)this).SetState(stateA, stateB);
 
         /// <inheritdoc />
-        public virtual void SetState(ulong stateA, ulong stateB, ulong stateC)
-        {
-            int c = StateCount;
-            for (int i = 0; i < c; i += 3)
-            {
-                SetSelectedState(i, stateA);
-            }
-            for (int i = 1; i < c; i += 3)
-            {
-                SetSelectedState(i, stateB);
-            }
-            for (int i = 2; i < c; i += 3)
-            {
-                SetSelectedState(i, stateC);
-            }
-        }
+        public virtual void SetState(ulong stateA, ulong stateB, ulong stateC) => ((IEnhancedRandom)this).SetState(stateA, stateB, stateC);
 
         /// <inheritdoc />
-        public virtual void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
-        {
-            int c = StateCount;
-            for (int i = 0; i < c; i += 4)
-            {
-                SetSelectedState(i, stateA);
-            }
-            for (int i = 1; i < c; i += 4)
-            {
-                SetSelectedState(i, stateB);
-            }
-            for (int i = 2; i < c; i += 4)
-            {
-                SetSelectedState(i, stateC);
-            }
-            for (int i = 3; i < c; i += 4)
-            {
-                SetSelectedState(i, stateD);
-            }
-        }
+        public virtual void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => ((IEnhancedRandom)this).SetState(stateA, stateB, stateC, stateD);
 
         /// <inheritdoc />
-        public virtual void SetState(params ulong[] states)
-        {
-            int c = StateCount, sl = states.Length;
-            for (int b = 0; b < sl; b++)
-            {
-                for (int i = b; i < c; i += sl)
-                {
-                    SetSelectedState(i, states[b]);
-                }
-            }
-        }
+        public virtual void SetState(params ulong[] states) => ((IEnhancedRandom)this).SetState(states);
 
         /// <inheritdoc />
         public abstract ulong NextULong();

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using ShaiRandom.Wrappers;
 
 namespace ShaiRandom.Generators

--- a/ShaiRandom/Generators/IEnhancedRandom.cs
+++ b/ShaiRandom/Generators/IEnhancedRandom.cs
@@ -104,7 +104,13 @@ namespace ShaiRandom.Generators
         /// If StateCount is more than 1, then all states will be set in the same way (using SetSelectedState(), all to state).
         /// </remarks>
         /// <param name="state">The ulong variable to use for every state variable.</param>
-        void SetState(ulong state);
+        void SetState(ulong state)
+        {
+            for (int i = StateCount - 1; i >= 0; i--)
+            {
+                SetSelectedState(i, state);
+            }
+        }
 
         /// <summary>
         /// Sets each state variable to either stateA or stateB, alternating.
@@ -117,7 +123,18 @@ namespace ShaiRandom.Generators
         /// </remarks>
         /// <param name="stateA">The ulong value to use for states at index 0, 2, 4, 6...</param>
         /// <param name="stateB">The ulong value to use for states at index 1, 3, 5, 7...</param>
-        void SetState(ulong stateA, ulong stateB);
+        void SetState(ulong stateA, ulong stateB)
+        {
+            int c = StateCount;
+            for (int i = 0; i < c; i += 2)
+            {
+                SetSelectedState(i, stateA);
+            }
+            for (int i = 1; i < c; i += 2)
+            {
+                SetSelectedState(i, stateB);
+            }
+        }
 
         /// <summary>
         /// Sets each state variable to stateA, stateB, or stateC, alternating.
@@ -134,7 +151,22 @@ namespace ShaiRandom.Generators
         /// <param name="stateA">The ulong value to use for states at index 0, 3, 6, 9...</param>
         /// <param name="stateB">The ulong value to use for states at index 1, 4, 7, 10...</param>
         /// <param name="stateC">The ulong value to use for states at index 2, 5, 8, 11...</param>
-        void SetState(ulong stateA, ulong stateB, ulong stateC);
+        void SetState(ulong stateA, ulong stateB, ulong stateC)
+        {
+            int c = StateCount;
+            for (int i = 0; i < c; i += 3)
+            {
+                SetSelectedState(i, stateA);
+            }
+            for (int i = 1; i < c; i += 3)
+            {
+                SetSelectedState(i, stateB);
+            }
+            for (int i = 2; i < c; i += 3)
+            {
+                SetSelectedState(i, stateC);
+            }
+        }
 
         /// <summary>
         /// Sets each state variable to stateA, stateB, stateC, or stateD, alternating.
@@ -154,7 +186,26 @@ namespace ShaiRandom.Generators
         /// <param name="stateB">the ulong value to use for states at index 1, 5, 9, 13...</param>
         /// <param name="stateC">the ulong value to use for states at index 2, 6, 10, 14...</param>
         /// <param name="stateD">the ulong value to use for states at index 3, 7, 11, 15...</param>
-        void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD);
+        void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD)
+        {
+            int c = StateCount;
+            for (int i = 0; i < c; i += 4)
+            {
+                SetSelectedState(i, stateA);
+            }
+            for (int i = 1; i < c; i += 4)
+            {
+                SetSelectedState(i, stateB);
+            }
+            for (int i = 2; i < c; i += 4)
+            {
+                SetSelectedState(i, stateC);
+            }
+            for (int i = 3; i < c; i += 4)
+            {
+                SetSelectedState(i, stateD);
+            }
+        }
 
         /// <summary>
         /// Sets all state variables to alternating values chosen from states. If states is empty,
@@ -164,7 +215,18 @@ namespace ShaiRandom.Generators
         /// uses <see cref="SetSelectedState(int, ulong)"/> to change the states.
         /// </summary>
         /// <param name="states">an array or varargs of ulong values to use as states</param>
-        void SetState(params ulong[] states);
+        void SetState(params ulong[] states)
+        {
+            int c = StateCount, sl = states.Length;
+            for (int b = 0; b < sl; b++)
+            {
+                for (int i = b; i < c; i += sl)
+                {
+                    SetSelectedState(i, states[b]);
+                }
+            }
+        }
+
         /// <summary>
         /// Can return any ulong.
         /// </summary>

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -14,7 +14,7 @@ namespace ShaiRandom.Generators
     ///
     /// This class is mostly from GoRogue, with some modifications for ShaiRandom's API.
     /// </remarks>
-    public class KnownSeriesRandom : AbstractRandom, IEquatable<KnownSeriesRandom?>
+    public class KnownSeriesRandom : IEnhancedRandom, IEquatable<KnownSeriesRandom?>
     {
         private int _boolIndex;
         private readonly List<bool> _boolSeries;
@@ -37,7 +37,8 @@ namespace ShaiRandom.Generators
         /// Creates a KnownSeriesRandom that is a copy of the given one.
         /// </summary>
         /// <param name="other">Generator to copy state from.</param>
-        public KnownSeriesRandom(KnownSeriesRandom other) : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries)
+        public KnownSeriesRandom(KnownSeriesRandom other)
+            : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries)
         {
             _intIndex = other._intIndex;
             _uintIndex = other._uintIndex;
@@ -73,8 +74,9 @@ namespace ShaiRandom.Generators
                                  IEnumerable<double>? doubleSeries = null, IEnumerable<bool>? boolSeries = null,
                                  IEnumerable<byte>? byteSeries = null, IEnumerable<float>? floatSeries = null,
                                  IEnumerable<long>? longSeries = null,IEnumerable<ulong>? ulongSeries = null)
-            : base(0UL)
         {
+            Seed(0L);
+
             _intSeries = intSeries == null ? new List<int>() : intSeries.ToList();
             _uintSeries = uintSeries == null ? new List<uint>() : uintSeries.ToList();
             _longSeries = longSeries == null ? new List<long>() : longSeries.ToList();
@@ -88,32 +90,32 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// This generator has 8 states; one for each type of IEnumerable taken in the constructor.
         /// </summary>
-        public override int StateCount => 8;
+        public int StateCount => 8;
 
         /// <summary>
         /// This supports <see cref="SelectState(int)"/>.
         /// </summary>
-        public override bool SupportsReadAccess => true;
+        public bool SupportsReadAccess => true;
 
         /// <summary>
         /// This supports <see cref="SetSelectedState(int, ulong)"/>.
         /// </summary>
-        public override bool SupportsWriteAccess => true;
+        public bool SupportsWriteAccess => true;
 
         /// <summary>
         /// This does NOT support <see cref="IEnhancedRandom.Skip(ulong)"/>.
         /// </summary>
-        public override bool SupportsSkip => false;
+        public bool SupportsSkip => false;
 
         /// <summary>
         /// This does NOT support <see cref="PreviousULong()"/>.
         /// </summary>
-        public override bool SupportsPrevious => false;
+        public bool SupportsPrevious => false;
 
         /// <summary>
         /// Generator is not serializable, and thus has no tag.
         /// </summary>
-        public override string Tag => throw new NotSupportedException("KnownSeriesRandom generators are not serializable, and thus have no Tag.");
+        public string Tag => throw new NotSupportedException("KnownSeriesRandom generators are not serializable, and thus have no Tag.");
 
         private static T ReturnIfRange<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
         {
@@ -166,7 +168,7 @@ namespace ShaiRandom.Generators
         }
 
         /// <inheritdoc />
-        public override IEnhancedRandom Copy() => new KnownSeriesRandom(this);
+        public IEnhancedRandom Copy() => new KnownSeriesRandom(this);
 
         /// <inheritdoc />
         public override bool Equals(object? obj) => obj is KnownSeriesRandom random && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
@@ -174,12 +176,25 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public bool Equals(KnownSeriesRandom? random) => random != null && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
 
-        /// <inheritdoc />
-        public override bool NextBool() => ReturnValueFrom(_boolSeries, ref _boolIndex);
+        /// <summary>
+        /// Returns the next boolean value from the underlying series.
+        /// </summary>
+        /// <returns>The next boolean value from the underlying series.</returns>
+        public bool NextBool() => ReturnValueFrom(_boolSeries, ref _boolIndex);
 
+        /// <summary>
+        /// Returns the next integer from the underlying series.
+        /// </summary>
+        /// <returns>The next integer from the underlying series.</returns>
+        public int NextInt() => ReturnValueFrom(_intSeries, ref _intIndex);
 
-        public new int NextInt() => ReturnValueFrom(_intSeries, ref _intIndex);
-        public new int NextInt(int outerBound) => NextInt(0, outerBound);
+        /// <summary>
+        /// Returns the next integer from underlying series, if it is within the bound; if not,
+        /// throws an exception.
+        /// </summary>
+        /// <param name="outerBound">The upper bound for the returned integer, exclusive.</param>
+        /// <returns>The next integer from the underlying series, if it is within the bound.</returns>
+        public int NextInt(int outerBound) => NextInt(0, outerBound);
 
         /// <summary>
         /// Returns the next integer in the underlying series. If the value is less than
@@ -188,10 +203,27 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next integer in the underlying series.</returns>
-        public new int NextInt(int minValue, int maxValue) => ReturnIfRange(minValue, maxValue, _intSeries, ref _intIndex);
-        public new uint NextUInt() => ReturnValueFrom(_uintSeries, ref _uintIndex);
-        public new uint NextUInt(uint outerBound) => NextUInt(0, outerBound);
-        public new uint NextBits(int bits) => (bits & 31) == 0 ? NextUInt() : NextUInt(0, 1U << bits);
+        public int NextInt(int minValue, int maxValue) => ReturnIfRange(minValue, maxValue, _intSeries, ref _intIndex);
+
+        /// <summary>
+        /// Returns the next uint in the underlying series.
+        /// </summary>
+        /// <returns>The next uint in the underlying series.</returns>
+        public uint NextUInt() => ReturnValueFrom(_uintSeries, ref _uintIndex);
+
+        /// <summary>
+        /// Returns the next uint in the underlying series.  If it is outside of the bound specified, throws an exception.
+        /// </summary>
+        /// <param name="outerBound">The upper bound for the returned uint, exclusive.</param>
+        /// <returns>The next uint in the underlying series, if it is within the bound.</returns>
+        public uint NextUInt(uint outerBound) => NextUInt(0, outerBound);
+
+        /// <summary>
+        /// Uses the next unsigned integer from the underlying series to return the specified number of bits.
+        /// </summary>
+        /// <param name="bits">Number of bits to return</param>
+        /// <returns>An integer containing the specified number of bits.</returns>
+        public uint NextBits(int bits) => (bits & 31) == 0 ? NextUInt() : NextUInt(0, 1U << bits);
 
         /// <summary>
         /// Returns the next unsigned integer in the underlying series. If the value is less than
@@ -200,35 +232,53 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next unsigned integer in the underlying series.</returns>
-        public new uint NextUInt(uint minValue, uint maxValue) => ReturnIfRange(minValue, maxValue, _uintSeries, ref _uintIndex);
+        public uint NextUInt(uint minValue, uint maxValue) => ReturnIfRange(minValue, maxValue, _uintSeries, ref _uintIndex);
 
-        public override double NextDouble() => ReturnValueFrom(_doubleSeries, ref _doubleIndex);
-        public new double NextDouble(double outerBound) => NextDouble(0.0, outerBound);
-        public new double NextDouble(double minBound, double maxBound) => ReturnIfRange(minBound, maxBound, _doubleSeries, ref _doubleIndex);
-        public new double NextInclusiveDouble() => NextInclusiveDouble(0f, 1f);
-        public new double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0f, outerBound);
-        public new double NextInclusiveDouble(double minBound, double maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
-        public new double NextExclusiveDouble() => NextExclusiveDouble(0f, 1f);
-        public new double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0f, outerBound);
-        public new double NextExclusiveDouble(double minBound, double maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
-        public override float NextFloat() => ReturnValueFrom(_floatSeries, ref _floatIndex);
-        public new float NextFloat(float outerBound) => NextFloat(0f, outerBound);
-        public new float NextFloat(float minBound, float maxBound) => ReturnIfRange(minBound, maxBound, _floatSeries, ref _floatIndex);
-        public new float NextInclusiveFloat() => NextInclusiveFloat(0f, 1f);
-        public new float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0f, outerBound);
-        public new float NextInclusiveFloat(float minBound, float maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
-        public new float NextExclusiveFloat() => NextExclusiveFloat(0f, 1f);
-        public new float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
-        public new float NextExclusiveFloat(float minBound, float maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
-        public float NextTriangular()
-        {
-            NextFloat(); // Used only to advance state the same number of times.
-            return NextExclusiveFloat(-1f, 1f);
-        }
-        public float NextTriangular(float min, float max) => NextExclusiveFloat(min, max);
-        public float NextTriangular(float min, float max, float mode) => NextExclusiveFloat(min, max);
-        public new long NextLong() => ReturnValueFrom(_longSeries, ref _longIndex);
-        public new long NextLong(long outerBound) => NextLong(0, outerBound);
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound [0, 1), throws
+        /// an exception.
+        /// </summary>
+        /// <returns>The next double in the underlying series, if it is within the bound.</returns>
+        public double NextDouble() => NextDouble(0.0, 1.0);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound specified, throws an exception.
+        /// </summary>
+        /// <param name="outerBound">The upper bound for the returned double, exclusive.</param>
+        /// <returns>The next double in the underlying series, if it is within the bound.</returns>
+        public double NextDouble(double outerBound) => NextDouble(0.0, outerBound);
+
+        /// <summary>
+        /// Returns the next double in the underlying series. If the value is less than
+        /// <paramref name="minBound"/>, or greater than/equal to <paramref name="maxBound"/>, throws an exception.
+        /// </summary>
+        /// <param name="minBound">The minimum value for the returned number, inclusive.</param>
+        /// <param name="maxBound">The maximum value for the returned number, exclusive.</param>
+        /// <returns>The next double in the underlying series.</returns>
+        public double NextDouble(double minBound, double maxBound) => ReturnIfRange(minBound, maxBound, _doubleSeries, ref _doubleIndex);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound [0, 1], throws
+        /// an exception.
+        /// </summary>
+        /// <returns>The next double in the underlying series, if it is within the bound.</returns>
+        public double NextInclusiveDouble() => NextInclusiveDouble(0f, 1f);
+        public double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0f, outerBound);
+        public double NextInclusiveDouble(double minBound, double maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
+        public double NextExclusiveDouble() => NextExclusiveDouble(0f, 1f);
+        public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0f, outerBound);
+        public double NextExclusiveDouble(double minBound, double maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
+        public float NextFloat() => ReturnValueFrom(_floatSeries, ref _floatIndex);
+        public float NextFloat(float outerBound) => NextFloat(0f, outerBound);
+        public float NextFloat(float minBound, float maxBound) => ReturnIfRange(minBound, maxBound, _floatSeries, ref _floatIndex);
+        public float NextInclusiveFloat() => NextInclusiveFloat(0f, 1f);
+        public float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0f, outerBound);
+        public float NextInclusiveFloat(float minBound, float maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
+        public float NextExclusiveFloat() => NextExclusiveFloat(0f, 1f);
+        public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
+        public float NextExclusiveFloat(float minBound, float maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
+        public long NextLong() => ReturnValueFrom(_longSeries, ref _longIndex);
+        public long NextLong(long outerBound) => NextLong(0, outerBound);
         /// <summary>
         /// Returns the next long in the underlying series. If the value is less than
         /// <paramref name="minValue"/>, or greater than/equal to <paramref name="maxValue"/>, throws an exception.
@@ -236,10 +286,10 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next long in the underlying series.</returns>
-        public new long NextLong(long minValue, long maxValue) => ReturnIfRange(minValue, maxValue, _longSeries, ref _longIndex);
+        public long NextLong(long minValue, long maxValue) => ReturnIfRange(minValue, maxValue, _longSeries, ref _longIndex);
 
-        public override ulong NextULong() => ReturnValueFrom(_ulongSeries, ref _ulongIndex);
-        public new ulong NextULong(ulong outerBound) => NextULong(0, outerBound);
+        public ulong NextULong() => ReturnValueFrom(_ulongSeries, ref _ulongIndex);
+        public ulong NextULong(ulong outerBound) => NextULong(0, outerBound);
         /// <summary>
         /// Returns the next ulong in the underlying series. If the value is less than
         /// <paramref name="minValue"/>, or greater than/equal to <paramref name="maxValue"/>, throws an exception.
@@ -247,20 +297,20 @@ namespace ShaiRandom.Generators
         /// <param name="minValue">The minimum value for the returned number, inclusive.</param>
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next ulong in the underlying series.</returns>
-        public new ulong NextULong(ulong minValue, ulong maxValue) => ReturnIfRange(minValue, maxValue, _ulongSeries, ref _ulongIndex);
+        public ulong NextULong(ulong minValue, ulong maxValue) => ReturnIfRange(minValue, maxValue, _ulongSeries, ref _ulongIndex);
 
 
         /// <summary>
         /// Fills the specified buffer with values from the underlying byte series.
         /// </summary>
         /// <param name="buffer">Buffer to fill.</param>
-        public new void NextBytes(byte[] buffer)
+        public void NextBytes(byte[] buffer)
         {
             for (int i = 0; i < buffer.Length; i++)
                 buffer[i] = ReturnValueFrom(_byteSeries, ref _byteIndex);
         }
-        public override ulong PreviousULong() => throw new NotImplementedException();
-        public override void Seed(ulong seed)
+        public ulong PreviousULong() => throw new NotSupportedException();
+        public void Seed(ulong seed)
         {
             int idx = (int)seed;
             _intIndex = idx;
@@ -272,7 +322,7 @@ namespace ShaiRandom.Generators
             _longIndex = idx;
             _ulongIndex = idx;
         }
-        public override ulong SelectState(int selection)
+        public ulong SelectState(int selection)
         {
             switch (selection)
             {
@@ -286,7 +336,7 @@ namespace ShaiRandom.Generators
                 default: return (ulong)_ulongIndex;
             }
         }
-        public override void SetSelectedState(int selection, ulong value)
+        public void SetSelectedState(int selection, ulong value)
         {
             switch (selection)
             {
@@ -300,14 +350,13 @@ namespace ShaiRandom.Generators
                 default: _ulongIndex = (int)value; break;
             }
         }
-        public override void SetState(ulong state) => Seed(state);
-        public override void SetState(ulong stateA, ulong stateB) => Seed(stateA);
-        public override void SetState(ulong stateA, ulong stateB, ulong stateC) => Seed(stateA);
-        public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Seed(stateA);
-        public override void SetState(params ulong[] states) => base.SetState(states);
-        public override ulong Skip(ulong distance) => throw new NotImplementedException();
-        public override IEnhancedRandom StringDeserialize(string data) => throw new NotImplementedException();
-        public override string StringSerialize() => throw new NotImplementedException();
+        public void SetState(ulong state) => Seed(state);
+        public void SetState(ulong stateA, ulong stateB) => Seed(stateA);
+        public void SetState(ulong stateA, ulong stateB, ulong stateC) => Seed(stateA);
+        public void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Seed(stateA);
+        public ulong Skip(ulong distance) => throw new NotSupportedException();
+        public IEnhancedRandom StringDeserialize(string data) => throw new NotSupportedException();
+        public string StringSerialize() => throw new NotSupportedException();
 
         public static bool operator ==(KnownSeriesRandom? left, KnownSeriesRandom? right) => EqualityComparer<KnownSeriesRandom>.Default.Equals(left, right);
         public static bool operator !=(KnownSeriesRandom? left, KnownSeriesRandom? right) => !(left == right);

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -263,12 +263,48 @@ namespace ShaiRandom.Generators
         /// </summary>
         /// <returns>The next double in the underlying series, if it is within the bound.</returns>
         public double NextInclusiveDouble() => NextInclusiveDouble(0f, 1f);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound [0, <paramref name="outerBound"/>], throws
+        /// an exception.
+        /// </summary>
+        /// <param name="outerBound">The maximum value of the returned number, inclusive.</param>
+        /// <returns>The next double in the underlying series, if it is within the bound.</returns>
         public double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0f, outerBound);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound [<paramref name="minBound"/>, <paramref name="maxBound"/>], throws
+        /// an exception.
+        /// </summary>
+        /// <param name="minBound">The minimum value of the returned number, inclusive.</param>
+        /// <param name="maxBound">The maximum value of the returned number, inclusive.</param>
+        /// <returns>The next double in the underlying series, if it is within the bounds.</returns>
         public double NextInclusiveDouble(double minBound, double maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound (0, 1), throws
+        /// an exception.
+        /// </summary>
+        /// <returns>The next double in the underlying series, if it is within the bound.</returns>
         public double NextExclusiveDouble() => NextExclusiveDouble(0f, 1f);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound ([)0, <paramref name="outerBound"/>), throws
+        /// an exception.
+        /// </summary>
+        /// <param name="outerBound">The maximum value of the returned number, exclusive.</param>
+        /// <returns>The next double in the underlying series, if it is within the bound.</returns>
         public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0f, outerBound);
+
+        /// <summary>
+        /// Returns the next double in the underlying series.  If it is outside of the bound (<paramref name="minBound"/>, <paramref name="maxBound"/>), throws
+        /// an exception.
+        /// </summary>
+        /// <param name="minBound">The minimum value of the returned number, exclusive.</param>
+        /// <param name="maxBound">The maximum value of the returned number, exclusive.</param>
+        /// <returns>The next double in the underlying series, if it is within the bounds.</returns>
         public double NextExclusiveDouble(double minBound, double maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
-        public float NextFloat() => ReturnValueFrom(_floatSeries, ref _floatIndex);
+        public float NextFloat() => NextFloat(0f, 1f);
         public float NextFloat(float outerBound) => NextFloat(0f, outerBound);
         public float NextFloat(float minBound, float maxBound) => ReturnIfRange(minBound, maxBound, _floatSeries, ref _floatIndex);
         public float NextInclusiveFloat() => NextInclusiveFloat(0f, 1f);
@@ -309,7 +345,16 @@ namespace ShaiRandom.Generators
             for (int i = 0; i < buffer.Length; i++)
                 buffer[i] = ReturnValueFrom(_byteSeries, ref _byteIndex);
         }
+
+        /// <summary>
+        /// Not supported by this generator.
+        /// </summary>
         public ulong PreviousULong() => throw new NotSupportedException();
+
+        /// <summary>
+        /// Sets the current index of each given sequence to the given seed value.
+        /// </summary>
+        /// <param name="seed">Index for the sequences.</param>
         public void Seed(ulong seed)
         {
             int idx = (int)seed;
@@ -322,6 +367,7 @@ namespace ShaiRandom.Generators
             _longIndex = idx;
             _ulongIndex = idx;
         }
+
         public ulong SelectState(int selection)
         {
             switch (selection)
@@ -336,6 +382,23 @@ namespace ShaiRandom.Generators
                 default: return (ulong)_ulongIndex;
             }
         }
+
+        /// <summary>
+        /// Sets the index for the given number series to the given value.
+        /// </summary>
+        /// <remarks>
+        /// The selection values start at 0, and they correspond to the constructor sequences as follows:
+        ///     - 0: intSeries
+        ///     - 1: uintSeries
+        ///     - 2: doubleSeries
+        ///     - 3: boolSeries
+        ///     - 4: byteSeries
+        ///     - 5: floatSeries
+        ///     - 6: longSeries
+        ///     - 7: ulongSeries
+        /// </remarks>
+        /// <param name="selection">Selection value of index to set.</param>
+        /// <param name="value">Value to set the index to.</param>
         public void SetSelectedState(int selection, ulong value)
         {
             switch (selection)
@@ -354,8 +417,20 @@ namespace ShaiRandom.Generators
         public void SetState(ulong stateA, ulong stateB) => Seed(stateA);
         public void SetState(ulong stateA, ulong stateB, ulong stateC) => Seed(stateA);
         public void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Seed(stateA);
+
+        /// <summary>
+        /// Not supported by this generator.
+        /// </summary>
         public ulong Skip(ulong distance) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Serialization is not supported by this generator.
+        /// </summary>
         public IEnhancedRandom StringDeserialize(string data) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Serialization is not supported by this generator.
+        /// </summary>
         public string StringSerialize() => throw new NotSupportedException();
 
         public static bool operator ==(KnownSeriesRandom? left, KnownSeriesRandom? right) => EqualityComparer<KnownSeriesRandom>.Default.Equals(left, right);

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -454,19 +454,34 @@ namespace ShaiRandom.Generators
             _ulongIndex = idx;
         }
 
+        /// <summary>
+        /// Retrieves the index of a given series based on the selection given. The selection values start at 0, and
+        /// they correspond to the constructor sequences as follows:
+        ///     - 0: intSeries
+        ///     - 1: uintSeries
+        ///     - 2: doubleSeries
+        ///     - 3: boolSeries
+        ///     - 4: byteSeries
+        ///     - 5: floatSeries
+        ///     - 6: longSeries
+        ///     - 7: ulongSeries
+        /// </summary>
+        /// <param name="selection">Selection value.</param>
+        /// <returns>The index of the selected series that will be returned next time that series is used.</returns>
         public ulong SelectState(int selection)
         {
-            switch (selection)
+            return selection switch
             {
-                case 0: return (ulong)_intIndex;
-                case 1: return (ulong)_uintIndex;
-                case 2: return (ulong)_doubleIndex;
-                case 3: return (ulong)_boolIndex;
-                case 4: return (ulong)_byteIndex;
-                case 5: return (ulong)_floatIndex;
-                case 6: return (ulong)_longIndex;
-                default: return (ulong)_ulongIndex;
-            }
+                0 => (ulong)_intIndex,
+                1 => (ulong)_uintIndex,
+                2 => (ulong)_doubleIndex,
+                3 => (ulong)_boolIndex,
+                4 => (ulong)_byteIndex,
+                5 => (ulong)_floatIndex,
+                6 => (ulong)_longIndex,
+                7 => (ulong)_ulongIndex,
+                _ => throw new ArgumentException("Invalid selector given to SelectState.", nameof(selection))
+            };
         }
 
         /// <summary>
@@ -499,10 +514,47 @@ namespace ShaiRandom.Generators
                 default: _ulongIndex = (int)value; break;
             }
         }
+        /// <summary>
+        /// Sets all the number series to the current index value.
+        /// </summary>
+        /// <param name="state">Value to set to all of the series indices.</param>
         public void SetState(ulong state) => Seed(state);
-        public void SetState(ulong stateA, ulong stateB) => Seed(stateA);
-        public void SetState(ulong stateA, ulong stateB, ulong stateC) => Seed(stateA);
+
+        /// <summary>
+        /// Sets the current indices in sequences as follows:
+        ///     - intSeries, doubleSeries, byteSeries, longSeries : stateA
+        ///     - uintSeries, boolSeries, floatSeries, ulongSeries: stateB
+        /// </summary>
+        /// <param name="stateA">Index value to set for intSeries, doubleSeries, byteSeries, and longSeries.</param>
+        /// <param name="stateB">Index value to set for uintSeries, boolSeries, floatSeries, ulongSeries.</param>
+        public void SetState(ulong stateA, ulong stateB) => ((IEnhancedRandom)this).SetState(stateA, stateB);
+
+        /// <summary>
+        /// Sets the current indices in sequences as follows:
+        ///     - intSeries, boolSeries, longSeries  : stateA
+        ///     - uintSeries, byteSeries, ulongSeries: stateB
+        ///     - doubleSeries, floatSeries          : stateC
+        /// </summary>
+        /// <param name="stateA">Index value to set for intSeries, boolSeries, and longSeries.</param>
+        /// <param name="stateB">Index value to set for uintSeries, byteSeries, ulongSeries.</param>
+        /// <param name="stateC">Index value to set for doubleSeries and floatSeries.</param>
+        public void SetState(ulong stateA, ulong stateB, ulong stateC) => ((IEnhancedRandom)this).SetState(stateA, stateB, stateC);
+
+        /// <summary>
+        /// Sets the current indices in sequences as follows:
+        ///     - intSeries, byteSeries   : stateA
+        ///     - uintSeries, floatSeries : stateB
+        ///     - doubleSeries, longSeries: stateC
+        ///     - boolSeries, ulongSeries : stateC
+        /// </summary>
+        /// <param name="stateA">Index value to set for intSeries and byteSeries.</param>
+        /// <param name="stateB">Index value to set for uintSeries and floatSeries.</param>
+        /// <param name="stateC">Index value to set for doubleSeries and longSeries.</param>
+        /// <param name="stateD">Index value to set for boolSeries and ulongSeries.</param>
         public void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Seed(stateA);
+
+        /// <inheritdoc />
+        public void SetState(params ulong[] states) => ((IEnhancedRandom)this).SetState(states);
 
         /// <summary>
         /// Not supported by this generator.

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -304,17 +304,92 @@ namespace ShaiRandom.Generators
         /// <param name="maxBound">The maximum value of the returned number, exclusive.</param>
         /// <returns>The next double in the underlying series, if it is within the bounds.</returns>
         public double NextExclusiveDouble(double minBound, double maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _doubleSeries, ref _doubleIndex);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound [0, 1), throws
+        /// an exception.
+        /// </summary>
+        /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextFloat() => NextFloat(0f, 1f);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound specified, throws an exception.
+        /// </summary>
+        /// <param name="outerBound">The upper bound for the returned float, exclusive.</param>
+        /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextFloat(float outerBound) => NextFloat(0f, outerBound);
+
+        /// <summary>
+        /// Returns the next float in the underlying series. If the value is less than
+        /// <paramref name="minBound"/>, or greater than/equal to <paramref name="maxBound"/>, throws an exception.
+        /// </summary>
+        /// <param name="minBound">The minimum value for the returned number, inclusive.</param>
+        /// <param name="maxBound">The maximum value for the returned number, exclusive.</param>
+        /// <returns>The next float in the underlying series.</returns>
         public float NextFloat(float minBound, float maxBound) => ReturnIfRange(minBound, maxBound, _floatSeries, ref _floatIndex);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound [0, 1], throws
+        /// an exception.
+        /// </summary>
+        /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextInclusiveFloat() => NextInclusiveFloat(0f, 1f);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound [0, <paramref name="outerBound"/>], throws
+        /// an exception.
+        /// </summary>
+        /// <param name="outerBound">The maximum value of the returned number, inclusive.</param>
+        /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0f, outerBound);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound [<paramref name="minBound"/>, <paramref name="maxBound"/>], throws
+        /// an exception.
+        /// </summary>
+        /// <param name="minBound">The minimum value of the returned number, inclusive.</param>
+        /// <param name="maxBound">The maximum value of the returned number, inclusive.</param>
+        /// <returns>The next float in the underlying series, if it is within the bounds.</returns>
         public float NextInclusiveFloat(float minBound, float maxBound) => ReturnIfRangeInclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound (0, 1), throws
+        /// an exception.
+        /// </summary>
+        /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextExclusiveFloat() => NextExclusiveFloat(0f, 1f);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound ([)0, <paramref name="outerBound"/>), throws
+        /// an exception.
+        /// </summary>
+        /// <param name="outerBound">The maximum value of the returned number, exclusive.</param>
+        /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
+
+        /// <summary>
+        /// Returns the next float in the underlying series.  If it is outside of the bound (<paramref name="minBound"/>, <paramref name="maxBound"/>), throws
+        /// an exception.
+        /// </summary>
+        /// <param name="minBound">The minimum value of the returned number, exclusive.</param>
+        /// <param name="maxBound">The maximum value of the returned number, exclusive.</param>
+        /// <returns>The next float in the underlying series, if it is within the bounds.</returns>
         public float NextExclusiveFloat(float minBound, float maxBound) => ReturnIfRangeBothExclusive(minBound, maxBound, _floatSeries, ref _floatIndex);
+
+        /// <summary>
+        /// Returns the next long from the underlying series.
+        /// </summary>
+        /// <returns>The next long from the underlying series.</returns>
         public long NextLong() => ReturnValueFrom(_longSeries, ref _longIndex);
+
+        /// <summary>
+        /// Returns the next long from underlying series, if it is within the bound; if not,
+        /// throws an exception.
+        /// </summary>
+        /// <param name="outerBound">The upper bound for the returned long, exclusive.</param>
+        /// <returns>The next long from the underlying series, if it is within the bound.</returns>
         public long NextLong(long outerBound) => NextLong(0, outerBound);
+
         /// <summary>
         /// Returns the next long in the underlying series. If the value is less than
         /// <paramref name="minValue"/>, or greater than/equal to <paramref name="maxValue"/>, throws an exception.
@@ -324,8 +399,20 @@ namespace ShaiRandom.Generators
         /// <returns>The next long in the underlying series.</returns>
         public long NextLong(long minValue, long maxValue) => ReturnIfRange(minValue, maxValue, _longSeries, ref _longIndex);
 
+        /// <summary>
+        /// Returns the next ulong from the underlying series.
+        /// </summary>
+        /// <returns>The next ulong from the underlying series.</returns>
         public ulong NextULong() => ReturnValueFrom(_ulongSeries, ref _ulongIndex);
+
+        /// <summary>
+        /// Returns the next ulong from underlying series, if it is within the bound; if not,
+        /// throws an exception.
+        /// </summary>
+        /// <param name="outerBound">The upper bound for the returned ulong, exclusive.</param>
+        /// <returns>The next ulong from the underlying series, if it is within the bound.</returns>
         public ulong NextULong(ulong outerBound) => NextULong(0, outerBound);
+
         /// <summary>
         /// Returns the next ulong in the underlying series. If the value is less than
         /// <paramref name="minValue"/>, or greater than/equal to <paramref name="maxValue"/>, throws an exception.
@@ -334,7 +421,6 @@ namespace ShaiRandom.Generators
         /// <param name="maxValue">The maximum value for the returned number, exclusive.</param>
         /// <returns>The next ulong in the underlying series.</returns>
         public ulong NextULong(ulong minValue, ulong maxValue) => ReturnIfRange(minValue, maxValue, _ulongSeries, ref _ulongIndex);
-
 
         /// <summary>
         /// Fills the specified buffer with values from the underlying byte series.

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -551,7 +551,7 @@ namespace ShaiRandom.Generators
         /// <param name="stateB">Index value to set for uintSeries and floatSeries.</param>
         /// <param name="stateC">Index value to set for doubleSeries and longSeries.</param>
         /// <param name="stateD">Index value to set for boolSeries and ulongSeries.</param>
-        public void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Seed(stateA);
+        public void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => ((IEnhancedRandom)this).SetState(stateA, stateB, stateC, stateD);
 
         /// <inheritdoc />
         public void SetState(params ulong[] states) => ((IEnhancedRandom)this).SetState(states);

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -33,6 +33,10 @@ namespace ShaiRandom.Generators
         private int _ulongIndex;
         private readonly List<ulong> _ulongSeries;
 
+        /// <summary>
+        /// Creates a KnownSeriesRandom that is a copy of the given one.
+        /// </summary>
+        /// <param name="other">Generator to copy state from.</param>
         public KnownSeriesRandom(KnownSeriesRandom other) : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries)
         {
             _intIndex = other._intIndex;
@@ -45,54 +49,40 @@ namespace ShaiRandom.Generators
             _ulongIndex = other._ulongIndex;
         }
 
+
         /// <summary>
         /// Creates a new known series generator, with parameters to indicate which series to use for
         /// the integer, unsigned integer, double, bool, and byte-based RNG functions. If null is
         /// specified, no values of that type may be returned, and functions that try to return a
         /// value of that type will throw an exception.
         /// </summary>
-        public KnownSeriesRandom(IEnumerable<int>? intSeries = null, IEnumerable<uint>? uintSeries = null, IEnumerable<double>? doubleSeries = null, IEnumerable<bool>? boolSeries = null, IEnumerable<byte>? byteSeries = null,
-            IEnumerable<float>? floatSeries = null, IEnumerable<long>? longSeries = null, IEnumerable<ulong>? ulongSeries = null) : base(0UL)
+        /// <remarks>
+        /// The values given for each series are looped over repeatedly as the appropriate function is called, so the
+        /// RNG functions can be called an arbitrary number of times; doing so will simply result in values from the
+        /// sequence being reused.
+        /// </remarks>
+        /// <param name="intSeries">Series of values to return via <see cref="NextInt()"/>.</param>
+        /// <param name="uintSeries">Series of values to return via <see cref="NextUInt()"/>.</param>
+        /// <param name="doubleSeries">Series of values to return via <see cref="NextDouble()"/>.</param>
+        /// <param name="boolSeries">Series of values to return via <see cref="NextBool()"/>.</param>
+        /// <param name="byteSeries">Series of values to return via <see cref="NextBytes(byte[])"/>.</param>
+        /// <param name="floatSeries">Series of values to return via <see cref="NextFloat()"/>.</param>
+        /// <param name="longSeries">Series of values to return via <see cref="NextLong()"/>.</param>
+        /// <param name="ulongSeries">Series of values to return via <see cref="NextULong()"/>.</param>
+        public KnownSeriesRandom(IEnumerable<int>? intSeries = null, IEnumerable<uint>? uintSeries = null,
+                                 IEnumerable<double>? doubleSeries = null, IEnumerable<bool>? boolSeries = null,
+                                 IEnumerable<byte>? byteSeries = null, IEnumerable<float>? floatSeries = null,
+                                 IEnumerable<long>? longSeries = null,IEnumerable<ulong>? ulongSeries = null)
+            : base(0UL)
         {
-            if (intSeries == null)
-                _intSeries = new List<int>();
-            else
-                _intSeries = intSeries.ToList();
-
-            if (uintSeries == null)
-                _uintSeries = new List<uint>();
-            else
-                _uintSeries = uintSeries.ToList();
-
-            if (longSeries == null)
-                _longSeries = new List<long>();
-            else
-                _longSeries = longSeries.ToList();
-
-            if (ulongSeries == null)
-                _ulongSeries = new List<ulong>();
-            else
-                _ulongSeries = ulongSeries.ToList();
-
-            if (doubleSeries == null)
-                _doubleSeries = new List<double>();
-            else
-                _doubleSeries = doubleSeries.ToList();
-
-            if (floatSeries == null)
-                _floatSeries = new List<float>();
-            else
-                _floatSeries = floatSeries.ToList();
-
-            if (boolSeries == null)
-                _boolSeries = new List<bool>();
-            else
-                _boolSeries = boolSeries.ToList();
-
-            if (byteSeries == null)
-                _byteSeries = new List<byte>();
-            else
-                _byteSeries = byteSeries.ToList();
+            _intSeries = intSeries == null ? new List<int>() : intSeries.ToList();
+            _uintSeries = uintSeries == null ? new List<uint>() : uintSeries.ToList();
+            _longSeries = longSeries == null ? new List<long>() : longSeries.ToList();
+            _ulongSeries = ulongSeries == null ? new List<ulong>() : ulongSeries.ToList();
+            _doubleSeries = doubleSeries == null ? new List<double>() : doubleSeries.ToList();
+            _floatSeries = floatSeries == null ? new List<float>() : floatSeries.ToList();
+            _boolSeries = boolSeries == null ? new List<bool>() : boolSeries.ToList();
+            _byteSeries = byteSeries == null ? new List<byte>() : byteSeries.ToList();
         }
 
         /// <summary>
@@ -184,9 +174,9 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public bool Equals(KnownSeriesRandom? random) => random != null && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
 
+        /// <inheritdoc />
         public override bool NextBool() => ReturnValueFrom(_boolSeries, ref _boolIndex);
 
-        public bool NextBool(float chance) => NextBool();
 
         public new int NextInt() => ReturnValueFrom(_intSeries, ref _intIndex);
         public new int NextInt(int outerBound) => NextInt(0, outerBound);

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -33,15 +33,6 @@ namespace ShaiRandom.Generators
         private int _ulongIndex;
         private readonly List<ulong> _ulongSeries;
 
-        public KnownSeriesRandom() : this(0UL)
-        {
-        }
-
-        public KnownSeriesRandom(ulong seed) : this(null, null, null, null, null, null, null, null)
-        {
-            Seed(seed);
-        }
-
         public KnownSeriesRandom(KnownSeriesRandom other) : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries)
         {
             _intIndex = other._intIndex;
@@ -132,7 +123,7 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// Generator is not serializable, and thus has no tag.
         /// </summary>
-        public override string Tag => "";
+        public override string Tag => throw new NotSupportedException("KnownSeriesRandom generators are not serializable, and thus have no Tag.");
 
         private static T ReturnIfRange<T>(T minValue, T maxValue, List<T> series, ref int seriesIndex) where T : IComparable<T>
         {


### PR DESCRIPTION
# Changes
- Removed 0-parameter constructor for `KnownSeriesRandom` because it produced a generator in an invalid state
    - The produced generator would have no number series associated with it, so all of its generation-related functions would produce an exception
    - If a user wants to produce a generator copied from another, they can use the copy-constructor instead
- Removed constructor for `KnownSeriesRandom` that took only a seed, because it produced a generator in an invalid state (see above)
- Documented virtually all `KnownSeriesRandom` functions
    - Explicit documentation is provided for most of the interface functions, which explains the semantics of those functions as they pertain to this generator
    - Equality-related functions were left undocumented (pending refactor later)
- Modified `KnownSeriesRandom` to avoid using the `new` keyword, and implement `IEnhancedRandom` directly (without the use of `AbstractRandom`
    - This fixes a host of bugs that can occur when the generator is used (see below)
- Modified `KnownSeriesRandom`'s `NextFloat` and `NextDouble` functions to return only values that respect the bounds defined in the `IEnhancedRandom` contract for those functions
    - This should allow the generator to be used in more cases (for testing) where a generic `IEnhancedRandom` is expected)
- Moved `AbstractRandom`'s implementation of the `SetState` methods to the interface, where it serves as a default method implementation
    - `AbstractRandom` still explicitly implements these functions (and forwards to the default method implementation of the interface), so the methods remain callable on an arbitrary `IEnhancedRandom` object regardless of the pointer it is accessed through.
- Modified `SetState` methods of `KnownSeriesRandom` to have behavior more consistent with typical `IEnhancedRandom` implementations of those functions
    - The functions now utilize all the state values given in alternating fashion, like the default interface implementations do.
- Miscellaneous code cleanup (mostly removing unnecessary `using` statements).

# End State/Goal
The KnownSeriesRandom changes revolve around the following goals:

## Fix KnownSeriesRandomBug
On the main branch, there is a bug which prevents this generator's usage as a generic generator in many cases.  Consider the following code:
```CS
        public static int MyIntKnown(KnownSeriesRandom rng) => rng.NextInt();

        public static int MyIntInterface(IEnhancedRandom rng) => rng.NextInt();

        public static void Main(string[] args)
        {
            var rng = new KnownSeriesRandom(intSeries: new[] { 1, 2, 3 });
            Console.WriteLine(MyIntKnown(rng));
            Console.WriteLine(MyIntInterface(rng));
        }
```
On the main branch, executing this code will result in an exception when `MyIntInterface(rng)` is called.  This is because `KnownSeriesRandom` is misusing `new` in order to override methods of `AbstractRandom` that are not virtual.  Since `new` does not result in `vtable` redirection, this results in the `KnownSeriesRandom` version of these methods being called _only_ when the method is called through a pointer to that particular class; the `AbstractRandom` version is called if the method is called through a pointer to, say, `IEnhancedRandom`.

This PR fixes this issue by removing `new` from the `KnownSeriesRandom` implementation, and having it implement `IEnhancedRandom` directly.  This makes more sense to me since it implements most of the methods differently than `AbstractRandom` anyway (particularly after the extension method refactor).

## Ensure KnownSeriesRandom vs IEnhancedRandom Consistency
There were a few places where the `KnownSeriesRandom` generator implementation deviated from the contract outlined by `IEnhancedRandom`.  This occurred primarily in 2 areas:

1. `NextDouble()` and `NextFloat()` could return any number (even ones outside the [0, 1) bound
2. The `SetState` mechanics utilized the values under different conditions as other generators.
    - Largely, all `SetState()` implementations in `KnownSeriesRandom` would only utilize the first value given, whereas the traditional implementation utilizes all the values in alternating fashion.
    
## Minimize Repetitive Code for IEnhancedRandom Implementations
One are where repetitive code tended to exist for `IEnhancedRandom` implementations revolved around the `SetState()` methods.  All of these methods basically function as wrappers that call `SetSelectedState` in a loop of some sort.  Many generators provide their own implementations, but they all appear to do the same thing, just in a more optimized or direct way.

The `SetState` methods _could_ function as extension methods; however generators also tend to provide some generator-specific information about the function in the documentation, which would be difficult to preserve if the methods were extension methods.  Therefore, I elected to make them default method implementations on the interface, under the following constraints:
1. All `SetState` overloads have default method implementations of the interface
2. `AbstractRandom` still specifies these methods as virtual and implements them by simply forwarding to the default method implementation on the interface.  This serves two purposes:
    - It allows users to call the `SetState` functions on any pointer to a class inheriting from `AbstractRandom`, thus removing the primary limitation of default interface methods in this case
    - It allows specific generators to still override the method and provide generator-specific documentation for it
    
This way, classes implementing `IEnhancedRandom` still have to implement `SetState`, but unless they have reason to do otherwise they can simply forward to the default interface implementation.

The only warnings left in `KnownSeriesRandom` now pertain to the `Equals` function, the `operator==` operator, or `GetHashCode`.  I elected to leave these as-is, because I believe these need to be corrected in other generators as well via a separate refactor.
