### PR TITLE
Spans indices ranges

### DIFF
--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -229,7 +229,7 @@ namespace ShaiRandom.Generators
         }
 
         /// <inheritdoc />
-        public void NextBytes(byte[] bytes)
+        public void NextBytes(Span<byte> bytes)
         {
             int bl = bytes.Length;
             for (int i = 0; i < bl;)

--- a/ShaiRandom/Generators/IEnhancedRandom.cs
+++ b/ShaiRandom/Generators/IEnhancedRandom.cs
@@ -317,11 +317,36 @@ namespace ShaiRandom.Generators
 
         /// <summary>
         /// Generates random bytes and places them into a user-supplied
-        /// byte array.  The number of random bytes produced is equal to
-        /// the length of the byte array.
+        /// span.  The number of random bytes produced is equal to
+        /// the length of the span.
         /// </summary>
-        /// <param name="bytes">the byte array to fill with random bytes</param>
-        void NextBytes(byte[] bytes);
+        /// <remarks>
+        /// Note that this function can easily accept an array as well, or anything else that can convert to span either
+        /// via either implicit or explicit conversion.  It can also fill only part of any such array or structure
+        /// (see examples).
+        /// <example>
+        /// <code>
+        /// // Fill whole array
+        /// myRng.NextBytes(myArray);
+        /// </code>
+        /// </example>
+        ///
+        /// <example>
+        /// <code>
+        /// // Fill the three elements starting at index 1
+        /// myRng.NextBytes(myArray.AsSpan(1, 3));
+        /// </code>
+        /// </example>
+        ///
+        /// <example>
+        /// <code>
+        /// // Fill all elements from index 1 to (but not including) the last element
+        /// myRng.NextBytes(myArray.AsSpan(1..^1));
+        /// </code>
+        /// </example>
+        /// </remarks>
+        /// <param name="bytes">The Span to fill with random bytes.</param>
+        void NextBytes(Span<byte> bytes);
 
         /// <summary>
         /// Returns the next pseudorandom, uniformly distributed int

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -250,32 +250,104 @@ namespace ShaiRandom.Generators
 
 
         /// <summary>
-        /// Gets a randomly-chosen item from the given non-null, non-empty array.
+        /// Gets a randomly-chosen item from the given non-empty span.
         /// </summary>
+        /// <remarks>
+        /// Note that this function can easily accept an array as well, or anything else that can convert to span either
+        /// via either implicit or explicit conversion (see examples).
+        /// <example>
+        /// <code>
+        /// myRng.RandomElement&lt;TypeOfElementsInMyArray&gt;(myArray);
+        /// myRng.RandomElement(myArray.AsSpan());
+        /// </code>
+        /// </example>
+        /// </remarks>
         /// <param name="rng" />
-        /// <typeparam name="T">The type of items in the array.</typeparam>
-        /// <param name="array">Must be non-null and non-empty.</param>
-        /// <returns>A randomly-chosen item from array.</returns>
-        public static T RandomElement<T>(this IEnhancedRandom rng, T[] array)
-            => array[rng.NextInt(array.Length)];
+        /// <typeparam name="T">The type of items in the span.</typeparam>
+        /// <param name="items">Must be non-empty.</param>
+        /// <returns>A randomly-chosen item from the span.</returns>
+        public static T RandomElement<T>(this IEnhancedRandom rng, ReadOnlySpan<T> items)
+            => items[rng.NextInt(items.Length)];
 
         /// <summary>
         /// Gets a randomly-chosen item from the given non-null, non-empty IList.
         /// </summary>
         /// <param name="rng" />
         /// <typeparam name="T">The type of items in the list.</typeparam>
-        /// <param name="list">Must be non-null and non-empty.</param>
+        /// <param name="items">Must be non-null and non-empty.</param>
         /// <returns>A randomly-chosen item from list.</returns>
-        public static T RandomElement<T>(this IEnhancedRandom rng, IList<T> list)
-            => list[rng.NextInt(list.Count)];
+        public static T RandomElement<T>(this IEnhancedRandom rng, IReadOnlyList<T> items)
+            => items[rng.NextInt(items.Count)];
 
         /// <summary>
-        /// Shuffles the given array in-place pseudo-randomly, using the Fisher-Yates (also called Knuth) shuffle algorithm.
+        /// Gets a randomly-chosen value that is a valid index for an item from the given non-empty span.
+        /// </summary>
+        /// <remarks>
+        /// Note that this function can easily accept an array as well, or anything else that can convert to span either
+        /// via either implicit or explicit conversion (see examples).
+        /// <example>
+        /// <code>
+        /// myRng.RandomIndex&lt;TypeOfElementsInMyArray&gt;(myArray);
+        /// myRng.RandomIndex(myArray.AsSpan());
+        /// </code>
+        /// </example>
+        /// </remarks>
+        /// <param name="rng" />
+        /// <typeparam name="T">The type of items in the span.</typeparam>
+        /// <param name="items">Must be non-empty.</param>
+        /// <returns>A randomly-chosen value that is a valid index in the span.</returns>
+        public static int RandomIndex<T>(this IEnhancedRandom rng, ReadOnlySpan<T> items)
+            => rng.NextInt(items.Length);
+
+        /// <summary>
+        /// Gets a randomly-chosen value that is a valid index for an item from the given non-null non-empty list.
         /// </summary>
         /// <param name="rng" />
-        /// <param name="items">an array of some reference type; must be non-null but may contain null items</param>
-        public static void Shuffle<T>(this IEnhancedRandom rng, T[] items)
-            => rng.Shuffle(items, 0, items.Length);
+        /// <typeparam name="T">The type of items in the list.</typeparam>
+        /// <param name="items">Must be non-null and non-empty.</param>
+        /// <returns>A randomly-chosen value that is a valid index in the list.</returns>
+        public static int RandomIndex<T>(this IEnhancedRandom rng, IReadOnlyList<T> items)
+            => rng.NextInt(items.Count);
+
+        /// <summary>
+        /// Shuffles the given Span in-place pseudo-randomly, using the Fisher-Yates (also called Knuth) shuffle algorithm.
+        /// </summary>
+        /// <remarks>
+        /// Note that this function can easily accept an array as well, or anything else that can convert to span either
+        /// via either implicit or explicit conversion.  It can also shuffle only part of any such array or structure
+        /// (see examples).
+        /// <example>
+        /// <code>
+        /// // Shuffle whole array (either works)
+        /// myRng.Shuffle&lt;TypeOfElementsInMyArray&gt;(myArray);
+        /// myRng.Shuffle(myArray.AsSpan());
+        /// </code>
+        /// </example>
+        ///
+        /// <example>
+        /// <code>
+        /// // Shuffle the three elements starting at index 1
+        /// myRng.Shuffle(myArray.AsSpan(1, 3));
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <code>
+        /// // Shuffle all elements from index 1 to (but not including) the last element
+        /// myRng.Shuffle(myArray.AsSpan(1..^1));
+        /// </code>
+        /// </example>
+        /// </remarks>
+        /// <typeparam name="T">Type of elements in the span</typeparam>
+        /// <param name="rng" />
+        /// <param name="items">A span of some type; may contain null items</param>
+        public static void Shuffle<T>(this IEnhancedRandom rng, Span<T> items)
+        {
+            for (int i = items.Length - 1; i > 0; i--)
+            {
+                int ii = rng.NextInt(0, i + 1);
+                (items[i], items[ii]) = (items[ii], items[i]);
+            }
+        }
 
         /// <summary>
         /// Shuffles the given IList in-place pseudo-randomly, using the Fisher-Yates (also called Knuth) shuffle algorithm.
@@ -284,24 +356,6 @@ namespace ShaiRandom.Generators
         /// <param name="items">an IList; must be non-null but may contain null items</param>
         public static void Shuffle<T>(this IEnhancedRandom rng, IList<T> items)
             => rng.Shuffle(items, 0, items.Count);
-
-        /// <summary>
-        /// Shuffles a section of the given array in-place pseudo-randomly, using the Fisher-Yates (also called Knuth) shuffle algorithm.
-        /// </summary>
-        /// <param name="rng" />
-        /// <param name="items">an array of some reference type; must be non-null but may contain null items</param>
-        /// <param name="offset">the index of the first element of the array that can be shuffled</param>
-        /// <param name="length">the length of the section to shuffle</param>
-        public static void Shuffle<T>(this IEnhancedRandom rng, T[] items, int offset, int length)
-        {
-            offset = Math.Min(Math.Max(0, offset), items.Length);
-            length = Math.Min(items.Length - offset, Math.Max(0, length));
-            for (int i = offset + length - 1; i > offset; i--)
-            {
-                int ii = rng.NextInt(offset, i + 1);
-                (items[i], items[ii]) = (items[ii], items[i]);
-            }
-        }
 
         /// <summary>
         /// Shuffles a section of the given IList in-place pseudo-randomly, using the Fisher-Yates (also called Knuth) shuffle algorithm.

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -255,12 +255,12 @@ namespace ShaiRandom.Generators
         /// Gets a randomly-chosen item from the given non-empty span.
         /// </summary>
         /// <remarks>
-        /// Note that this function can easily accept an array as well, or anything else that can convert to span either
-        /// via either implicit or explicit conversion (see examples).
+        /// Note that this function can easily accept an array as well, or anything else that can convert to span
+        /// via either implicit or explicit conversion (see examples).  There is also an overload taking IReadOnlyList,
+        /// which can also take arrays.
         /// <example>
         /// <code>
-        /// myRng.RandomElement&lt;TypeOfElementsInMyArray&gt;(myArray);
-        /// myRng.RandomElement(myArray.AsSpan());
+        /// myRng.RandomElement&lt;TypeOfElementsInMyArray&gt;(myArray.AsSpan());
         /// </code>
         /// </example>
         /// </remarks>
@@ -272,7 +272,7 @@ namespace ShaiRandom.Generators
             => items[rng.NextInt(items.Length)];
 
         /// <summary>
-        /// Gets a randomly-chosen item from the given non-null, non-empty IList.
+        /// Gets a randomly-chosen item from the given non-null, non-empty IReadOnlyList.
         /// </summary>
         /// <param name="rng" />
         /// <typeparam name="T">The type of items in the list.</typeparam>
@@ -286,11 +286,11 @@ namespace ShaiRandom.Generators
         /// </summary>
         /// <remarks>
         /// Note that this function can easily accept an array as well, or anything else that can convert to span either
-        /// via either implicit or explicit conversion (see examples).
+        /// via either implicit or explicit conversion (see examples).  There is also an overload taking IReadOnlyList,
+        /// which can also take arrays.
         /// <example>
         /// <code>
-        /// myRng.RandomIndex&lt;TypeOfElementsInMyArray&gt;(myArray);
-        /// myRng.RandomIndex(myArray.AsSpan());
+        /// myRng.RandomIndex&lt;TypeOfElementsInMyArray&gt;(myArray.AsSpan());
         /// </code>
         /// </example>
         /// </remarks>
@@ -302,7 +302,7 @@ namespace ShaiRandom.Generators
             => rng.NextInt(items.Length);
 
         /// <summary>
-        /// Gets a randomly-chosen value that is a valid index for an item from the given non-null non-empty list.
+        /// Gets a randomly-chosen value that is a valid index for an item from the given non-null non-empty IReadOnlyList.
         /// </summary>
         /// <param name="rng" />
         /// <typeparam name="T">The type of items in the list.</typeparam>

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -346,7 +346,7 @@ namespace ShaiRandom.Generators
         {
             for (int i = items.Length - 1; i > 0; i--)
             {
-                int ii = rng.NextInt(0, i + 1);
+                int ii = rng.NextInt(i + 1);
                 (items[i], items[ii]) = (items[ii], items[i]);
             }
         }

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -423,13 +423,14 @@ namespace ShaiRandom.Generators
         public ulong NextULong(ulong minValue, ulong maxValue) => ReturnIfRange(minValue, maxValue, _ulongSeries, ref _ulongIndex);
 
         /// <summary>
-        /// Fills the specified buffer with values from the underlying byte series.
+        /// Fills the specified buffer with values from the underlying byte series.  See <see cref="IEnhancedRandom.NextBytes"/>
+        /// for detailed examples on various uses.
         /// </summary>
-        /// <param name="buffer">Buffer to fill.</param>
-        public void NextBytes(byte[] buffer)
+        /// <param name="bytes">Buffer to fill.</param>
+        public void NextBytes(Span<byte> bytes)
         {
-            for (int i = 0; i < buffer.Length; i++)
-                buffer[i] = ReturnValueFrom(_byteSeries, ref _byteIndex);
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = ReturnValueFrom(_byteSeries, ref _byteIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
# Changes
- `IEnhancedRandom.NextBytes(byte[]) now takes `Span<byte>` as its parameter instead
    - Adds support for numerous use cases, including filling only part of an array, via span conversion and slicing
- `Shuffle` functions now take `Span<T>` instead of `T[]`
    - See above
- `Shuffle(T[], int, int)` function has been removed
    - Use case now covered by converting an array to Span and using Span slicing techniques
- `Shuffle` functions now throw exceptions if values are given which are out of bounds
    - Maintains consistency with C# slicing/substring APIs
- List variants of `Shuffle` now take Range, Index, and integer start and/or end indices
    - This allows more flexibility in how a user defines the subsection of a list, and more or less mimics the slicing interface Span uses.
- `RandomElement(T[])` function now takes `ReadOnlySpan<T>` instead
    - See above; also adds the ability to retrieve a random item from a string using this function
- `RandomElement(IList<T>)` function now takes `IReadOnlyList<T>` instead
- Added `RandomIndex` functions which take a span or read-only list and return a valid index in that list, instead of an item

# End State/Goal
The changes are, in general, designed to increase the flexibility of the API, and avoid duplicating code wherever possible.  

Arrays implicitly convert to spans (as well as `IReadOnlyList`, as it turns out); and spans support slicing syntax, Index, and Range out of the box; so switching the APIs to Span/ReadOnlySpan gains all these features without needing to write extra code for them when dealing with arrays or anything else that can convert to Span.

Note that there are some (C#) caveats here where a user needs to be careful when using the slicing features to avoid duplicating data.  An example:
```CS
int[] arr = {1, 2, 3, 4, 5};
// Array is allocated and appropriate values are copied; not good if you're passing this to Shuffle
int[] slice = arr[1..^1];
```

There are numerous workarounds to these types of issues in C#; primarily converting to Span.  As a result of this, however, I elected to provide _only_ a `Span` version of many of these functions, rather than providing both `Span` and array specifically.  This minimizes the chance of a user accidentally duplicating data as they pass it in, and maximizes the chance of the compiler and/or analyzer being able to notice and warn the user if they do so; and additionally results in the least code duplication for the library writer.

The Shuffle function that took an array as well as offset of length was removed, since this functionality can be obtained by creating spans of arrays.

Additionally, `Shuffle` functions now intentionally throw exceptions if values are out of bounds.  Since the slicing/span/substring APIs in C# tend to throw exceptions in these situations, this change should help to maintain consistency across the various Shuffle functions, as well as with the C# APIs at large.

Finally, a number of list-related Shuffle functions have been added that take `Index` and `Range` as parameters.  Since lists cannot convert to spans (at least, not until .NET 5), this set of functions effectively mimics the Span creation/slicing interface, in order to provide a more flexible set of options.  A sampling of some things that will now work with lists:

```CS
var list = new List<int> {1, 2, 3, 4, 5};

// Shuffle from index 1 to end (either works)
rng.Shuffle(list, 1);
rng.Shuffle(list, 1..);

// Shuffle from index 1 to (but not including) the last index (eg shuffle [2, 3, 4])
rng.Shuffle(list, 1..^1);

// Shuffle the last three elements
rng.Shuffle(list, ^3);
```