### PR TITLE
Fix Virtual Methods in Constructor, Equality, and Other Warnings

### DIFF
--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -103,7 +103,7 @@ namespace ShaiRandom.UnitTests
             Assert.StartsWith("#FoWR`", data);
             IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
             Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(AbstractRandom.AreEqual(random, random2));
+            Assert.True(random.Matches(random2));
         }
         [Fact]
         public void StrangerSerDeserTest()
@@ -114,7 +114,7 @@ namespace ShaiRandom.UnitTests
             Assert.StartsWith("#StrR`", data);
             IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
             Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(AbstractRandom.AreEqual(random, random2));
+            Assert.True(random.Matches(random2));
         }
 
         [Fact]
@@ -126,7 +126,7 @@ namespace ShaiRandom.UnitTests
             Assert.StartsWith("TFoWR`", data);
             IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
             Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(AbstractRandom.AreEqual(random, random2));
+            Assert.True(random.Matches(random2));
         }
 
         [Fact]
@@ -138,7 +138,7 @@ namespace ShaiRandom.UnitTests
             Assert.StartsWith("RFoWR`", data);
             IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
             Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(AbstractRandom.AreEqual(random, random2));
+            Assert.True(random.Matches(random2));
         }
     }
 }

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -441,33 +441,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public abstract IEnhancedRandom Copy();
-
-        /// <summary>
-        /// Given two EnhancedRandom objects that could have the same or different classes,
-        /// this returns true if they have the same class and same state, or false otherwise.
-        /// </summary>
-        /// <remarks>
-        /// Both of the arguments should implement <see cref="SelectState(int)"/>, or this
-        /// will throw an UnsupportedOperationException. This can be useful for comparing
-        /// EnhancedRandom classes that do not implement Equals(), for whatever reason.
-        /// </remarks>
-        /// <param name="left">An EnhancedRandom to compare for equality</param>
-        /// <param name="right">Another EnhancedRandom to compare for equality</param>
-        /// <returns>true if the two EnhancedRandom objects have the same class and state, or false otherwise</returns>
-        public static bool AreEqual(IEnhancedRandom left, IEnhancedRandom right)
-        {
-            if (left == right)
-                return true;
-            if (left.GetType() != right.GetType())
-                return false;
-
-            int count = left.StateCount;
-            for (int i = 0; i < count; i++)
-            {
-                if (left.SelectState(i) != right.SelectState(i))
-                    return false;
-            }
-            return true;
-        }
     }
 }

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -32,21 +32,6 @@ namespace ShaiRandom.Generators
                 return (ulong)SeedingRandom.Next() ^ (ulong)SeedingRandom.Next() << 21 ^ (ulong)SeedingRandom.Next() << 42;
             }
         }
-        /// <summary>
-        /// Must have a zero-argument constructor.
-        /// </summary>
-        protected AbstractRandom()
-        {
-        }
-
-        /// <summary>
-        /// Copies another AbstractRandom, typically with the same class, into this newly-constructed one.
-        /// </summary>
-        /// <param name="other">Another AbstractRandom to copy into this one.</param>
-        protected AbstractRandom(AbstractRandom other)
-        {
-            this.SetWith(other);
-        }
 
         /// <inheritdoc />
         public abstract void Seed(ulong seed);

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -15,8 +15,8 @@ namespace ShaiRandom.Generators
     [Serializable]
     public abstract class AbstractRandom : IEnhancedRandom
     {
-        private static readonly float FLOAT_ADJUST = MathF.Pow(2f, -24f);
-        private static readonly double DOUBLE_ADJUST = Math.Pow(2.0, -53.0);
+        private static readonly float s_floatAdjust = MathF.Pow(2f, -24f);
+        private static readonly double s_doubleAdjust = Math.Pow(2.0, -53.0);
         /// <summary>
         /// Used by <see cref="MakeSeed"/> to produce mid-low quality random numbers as a starting seed, as a "don't care" option for seeding.
         /// </summary>
@@ -281,7 +281,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public virtual float NextFloat()
         {
-            return (NextULong() >> 40) * FLOAT_ADJUST;
+            return (NextULong() >> 40) * s_floatAdjust;
         }
 
         /// <inheritdoc />
@@ -300,7 +300,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public virtual double NextDouble()
         {
-            return (NextULong() >> 11) * DOUBLE_ADJUST;
+            return (NextULong() >> 11) * s_doubleAdjust;
         }
 
         /// <inheritdoc />
@@ -318,7 +318,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public double NextInclusiveDouble()
         {
-            return NextULong(0x20000000000001L) * DOUBLE_ADJUST;
+            return NextULong(0x20000000000001L) * s_doubleAdjust;
         }
 
         /// <inheritdoc />
@@ -336,7 +336,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public float NextInclusiveFloat()
         {
-            return NextInt(0x1000001) * FLOAT_ADJUST;
+            return NextInt(0x1000001) * s_floatAdjust;
         }
 
         /// <inheritdoc />

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -38,14 +38,7 @@ namespace ShaiRandom.Generators
         protected AbstractRandom()
         {
         }
-        /// <summary>
-        /// This calls <see cref="Seed(ulong)"/> with it seed by default.
-        /// </summary>
-        /// <param name="seed">A ulong that will either be used as a state verbatim or, more commonly, to determine multiple states.</param>
-        protected AbstractRandom(ulong seed)
-        {
-            Seed(seed);
-        }
+
         /// <summary>
         /// Copies another AbstractRandom, typically with the same class, into this newly-constructed one.
         /// </summary>

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -8,7 +7,7 @@ namespace ShaiRandom.Generators
     /// Note that this generator only returns each ulong result exactly once over its period.
     /// </summary>
     [Serializable]
-    public class DistinctRandom : AbstractRandom, IEquatable<DistinctRandom?>
+    public class DistinctRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "DisR" .
@@ -157,17 +156,5 @@ namespace ShaiRandom.Generators
             State = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as DistinctRandom);
-
-        /// <inheritdoc />
-        public bool Equals(DistinctRandom? other) => other != null && State == other.State;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(State);
-
-        public static bool operator ==(DistinctRandom? left, DistinctRandom? right) => EqualityComparer<DistinctRandom>.Default.Equals(left, right);
-        public static bool operator !=(DistinctRandom? left, DistinctRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -54,7 +54,7 @@ namespace ShaiRandom.Generators
          */
         public FourWheelRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -147,7 +147,9 @@ namespace ShaiRandom.Generators
          * different for every different {@code seed}).
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(FourWheelRandom rng, ulong seed)
         {
             unchecked
             {
@@ -156,25 +158,25 @@ namespace ShaiRandom.Generators
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateA = x ^ x >> 27;
+                rng.StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateB = x ^ x >> 27;
+                rng.StateB = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateC = x ^ x >> 27;
+                rng.StateC = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateD = x ^ x >> 27;
+                rng.StateD = x ^ x >> 27;
             }
         }
 

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -7,7 +6,7 @@ namespace ShaiRandom.Generators
     /// It's an AbstractRandom with 4 states, more here later.
     /// </summary>
     [Serializable]
-    public class FourWheelRandom : AbstractRandom, IEquatable<FourWheelRandom?>
+    public class FourWheelRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "FoWR" .
@@ -249,17 +248,5 @@ namespace ShaiRandom.Generators
             StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as FourWheelRandom);
-
-        /// <inheritdoc />
-        public bool Equals(FourWheelRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC && StateD == other.StateD;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC, StateD);
-
-        public static bool operator ==(FourWheelRandom? left, FourWheelRandom? right) => EqualityComparer<FourWheelRandom>.Default.Equals(left, right);
-        public static bool operator !=(FourWheelRandom? left, FourWheelRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace ShaiRandom.Generators

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -538,5 +538,30 @@ namespace ShaiRandom.Generators
                 rng.SetSelectedState(i, 0xFFFFFFFFFFFFFFFFUL);
             }
         }
+
+        /// <summary>
+        /// Given two IEnhancedRandom objects that could have the same or different classes,
+        /// this returns true if they have the same class and same state, or false otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Both of the arguments should implement <see cref="IEnhancedRandom.SelectState(int)"/>, or this
+        /// will throw an exception. This can be useful for comparing IEnhancedRandom classes.
+        /// </remarks>
+        /// <returns>true if the two objects have the same class and state, or false otherwise</returns>
+        public static bool Matches(this IEnhancedRandom left, IEnhancedRandom right)
+        {
+            if (left == right)
+                return true;
+            if (left.GetType() != right.GetType())
+                return false;
+
+            int count = left.StateCount;
+            for (int i = 0; i < count; i++)
+            {
+                if (left.SelectState(i) != right.SelectState(i))
+                    return false;
+            }
+            return true;
+        }
     }
 }

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -14,7 +14,7 @@ namespace ShaiRandom.Generators
     ///
     /// This class is mostly from GoRogue, with some modifications for ShaiRandom's API.
     /// </remarks>
-    public class KnownSeriesRandom : IEnhancedRandom, IEquatable<KnownSeriesRandom?>
+    public class KnownSeriesRandom : IEnhancedRandom
     {
         private int _boolIndex;
         private readonly List<bool> _boolSeries;
@@ -169,12 +169,6 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public IEnhancedRandom Copy() => new KnownSeriesRandom(this);
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => obj is KnownSeriesRandom random && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
-
-        /// <inheritdoc />
-        public bool Equals(KnownSeriesRandom? random) => random != null && StateCount == random.StateCount && _boolIndex == random._boolIndex && EqualityComparer<List<bool>>.Default.Equals(_boolSeries, random._boolSeries) && _byteIndex == random._byteIndex && EqualityComparer<List<byte>>.Default.Equals(_byteSeries, random._byteSeries) && _doubleIndex == random._doubleIndex && EqualityComparer<List<double>>.Default.Equals(_doubleSeries, random._doubleSeries) && _floatIndex == random._floatIndex && EqualityComparer<List<float>>.Default.Equals(_floatSeries, random._floatSeries) && _intIndex == random._intIndex && EqualityComparer<List<int>>.Default.Equals(_intSeries, random._intSeries) && _uintIndex == random._uintIndex && EqualityComparer<List<uint>>.Default.Equals(_uintSeries, random._uintSeries) && _longIndex == random._longIndex && EqualityComparer<List<long>>.Default.Equals(_longSeries, random._longSeries) && _ulongIndex == random._ulongIndex && EqualityComparer<List<ulong>>.Default.Equals(_ulongSeries, random._ulongSeries);
 
         /// <summary>
         /// Returns the next boolean value from the underlying series.
@@ -571,8 +565,5 @@ namespace ShaiRandom.Generators
         /// Serialization is not supported by this generator.
         /// </summary>
         public string StringSerialize() => throw new NotSupportedException();
-
-        public static bool operator ==(KnownSeriesRandom? left, KnownSeriesRandom? right) => EqualityComparer<KnownSeriesRandom>.Default.Equals(left, right);
-        public static bool operator !=(KnownSeriesRandom? left, KnownSeriesRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -66,7 +66,7 @@ namespace ShaiRandom.Generators
         /// <param name="uintSeries">Series of values to return via <see cref="NextUInt()"/>.</param>
         /// <param name="doubleSeries">Series of values to return via <see cref="NextDouble()"/>.</param>
         /// <param name="boolSeries">Series of values to return via <see cref="NextBool()"/>.</param>
-        /// <param name="byteSeries">Series of values to return via <see cref="NextBytes(byte[])"/>.</param>
+        /// <param name="byteSeries">Series of values to return via <see cref="NextBytes(Span&lt;byte&gt;)"/>.</param>
         /// <param name="floatSeries">Series of values to return via <see cref="NextFloat()"/>.</param>
         /// <param name="longSeries">Series of values to return via <see cref="NextLong()"/>.</param>
         /// <param name="ulongSeries">Series of values to return via <see cref="NextULong()"/>.</param>

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -52,7 +52,7 @@ namespace ShaiRandom.Generators
          */
         public LaserRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -129,7 +129,9 @@ namespace ShaiRandom.Generators
          * (2 to the 64) possible initial generator states can be produced here.
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(LaserRandom rng, ulong seed)
         {
             unchecked
             {
@@ -138,13 +140,13 @@ namespace ShaiRandom.Generators
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateA = x ^ x >> 27;
+                rng.StateA = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                _b = (x ^ x >> 27) | 1UL;
+                rng._b = (x ^ x >> 27) | 1UL;
             }
         }
 

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -7,7 +6,7 @@ namespace ShaiRandom.Generators
     /// It's an AbstractRandom with 2 states, more here later. This one supports <see cref="Skip(ulong)"/>.
     /// </summary>
     [Serializable]
-    public class LaserRandom : AbstractRandom, IEquatable<LaserRandom?>
+    public class LaserRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "LasR" .
@@ -212,17 +211,5 @@ namespace ShaiRandom.Generators
             StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as LaserRandom);
-
-        /// <inheritdoc />
-        public bool Equals(LaserRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB);
-
-        public static bool operator ==(LaserRandom? left, LaserRandom? right) => EqualityComparer<LaserRandom>.Default.Equals(left, right);
-        public static bool operator !=(LaserRandom? left, LaserRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -57,7 +57,7 @@ namespace ShaiRandom.Generators
          */
         public MizuchiRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -134,7 +134,9 @@ namespace ShaiRandom.Generators
          * (2 to the 64) possible initial generator states can be produced here.
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(MizuchiRandom rng, ulong seed)
         {
             unchecked
             {
@@ -143,13 +145,13 @@ namespace ShaiRandom.Generators
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateA = x ^ x >> 27;
+                rng.StateA = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                _b = (x ^ x >> 27) | 1UL;
+                rng._b = (x ^ x >> 27) | 1UL;
             }
         }
 

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -12,7 +11,7 @@ namespace ShaiRandom.Generators
     /// and since this supports multiple streams (by changing StateB), the waterway theme seemed fitting.
     /// </remarks>
     [Serializable]
-    public class MizuchiRandom : AbstractRandom, IEquatable<MizuchiRandom?>
+    public class MizuchiRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "MizR" .
@@ -205,17 +204,5 @@ namespace ShaiRandom.Generators
             StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as MizuchiRandom);
-
-        /// <inheritdoc />
-        public bool Equals(MizuchiRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB);
-
-        public static bool operator ==(MizuchiRandom? left, MizuchiRandom? right) => EqualityComparer<MizuchiRandom>.Default.Equals(left, right);
-        public static bool operator !=(MizuchiRandom? left, MizuchiRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -85,7 +85,7 @@ namespace ShaiRandom.Generators
          */
         public RomuTrioRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -171,7 +171,9 @@ namespace ShaiRandom.Generators
          * different for every different {@code seed}).
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(RomuTrioRandom rng, ulong seed)
         {
             unchecked
             {
@@ -180,19 +182,19 @@ namespace ShaiRandom.Generators
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateA = x ^ x >> 27;
+                rng.StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateB = x ^ x >> 27;
+                rng.StateB = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateC = x ^ x >> 27;
+                rng.StateC = x ^ x >> 27;
             }
         }
 

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -18,7 +18,6 @@
 // implementation of https://romu-random.org/ .
 
 using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -27,7 +26,7 @@ namespace ShaiRandom.Generators
     /// TricycleRandom or FourWheelRandom may be about the same speed or faster.
     /// </summary>
     [Serializable]
-    public class RomuTrioRandom : AbstractRandom, IEquatable<RomuTrioRandom?>
+    public class RomuTrioRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "RTrR" .
@@ -246,17 +245,5 @@ namespace ShaiRandom.Generators
             StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as RomuTrioRandom);
-
-        /// <inheritdoc />
-        public bool Equals(RomuTrioRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC);
-
-        public static bool operator ==(RomuTrioRandom? left, RomuTrioRandom? right) => EqualityComparer<RomuTrioRandom>.Default.Equals(left, right);
-        public static bool operator !=(RomuTrioRandom? left, RomuTrioRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -7,7 +6,7 @@ namespace ShaiRandom.Generators
     /// It's an AbstractRandom with 4 states, more here later. This one has a good guaranteed minimum period, (2 to the 65) - 2.
     /// </summary>
     [Serializable]
-    public class StrangerRandom : AbstractRandom, IEquatable<StrangerRandom?>
+    public class StrangerRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "StrR" .
@@ -267,17 +266,5 @@ namespace ShaiRandom.Generators
             StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as StrangerRandom);
-
-        /// <inheritdoc />
-        public bool Equals(StrangerRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC && StateD == other.StateD;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC, StateD);
-
-        public static bool operator ==(StrangerRandom? left, StrangerRandom? right) => EqualityComparer<StrangerRandom>.Default.Equals(left, right);
-        public static bool operator !=(StrangerRandom? left, StrangerRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -80,7 +80,7 @@ namespace ShaiRandom.Generators
          */
         public StrangerRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -93,7 +93,10 @@ namespace ShaiRandom.Generators
          */
         public StrangerRandom(ulong stateA, ulong stateC, ulong stateD)
         {
-            SetState(stateA, stateC, stateD);
+            StateA = stateA;
+            _b = Jump(_a);
+            StateC = stateC;
+            StateD = stateD;
         }
 
         /**
@@ -186,13 +189,15 @@ namespace ShaiRandom.Generators
          * different for every different {@code seed}).
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(StrangerRandom rng, ulong seed)
         {
-            StateA = seed ^ 0xFA346CBFD5890825UL;
-            if (StateA == 0UL) StateA = 0xD3833E804F4C574BUL;
-            _b = Jump(_a);
-            StateC = Jump(_b - seed);
-            StateD = Jump(StateC + 0xC6BC279692B5C323UL);
+            rng.StateA = seed ^ 0xFA346CBFD5890825UL;
+            if (rng.StateA == 0UL) rng.StateA = 0xD3833E804F4C574BUL;
+            rng._b = Jump(rng._a);
+            rng.StateC = Jump(rng._b - seed);
+            rng.StateD = Jump(rng.StateC + 0xC6BC279692B5C323UL);
         }
 
         /**

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -7,7 +6,7 @@ namespace ShaiRandom.Generators
     /// It's an AbstractRandom with 3 states, more here later.
     /// </summary>
     [Serializable]
-    public class TricycleRandom : AbstractRandom, IEquatable<TricycleRandom?>
+    public class TricycleRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "TriR" .
@@ -94,15 +93,12 @@ namespace ShaiRandom.Generators
          */
         public override ulong SelectState(int selection)
         {
-            switch (selection)
+            return selection switch
             {
-                case 0:
-                    return StateA;
-                case 1:
-                    return StateB;
-                default:
-                    return StateC;
-            }
+                0 => StateA,
+                1 => StateB,
+                _ => StateC
+            };
         }
 
         /**
@@ -223,17 +219,5 @@ namespace ShaiRandom.Generators
             StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as TricycleRandom);
-
-        /// <inheritdoc />
-        public bool Equals(TricycleRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC);
-
-        public static bool operator ==(TricycleRandom? left, TricycleRandom? right) => EqualityComparer<TricycleRandom>.Default.Equals(left, right);
-        public static bool operator !=(TricycleRandom? left, TricycleRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -49,7 +49,7 @@ namespace ShaiRandom.Generators
          */
         public TricycleRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -135,7 +135,9 @@ namespace ShaiRandom.Generators
          * different for every different {@code seed}).
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(TricycleRandom rng, ulong seed)
         {
             unchecked
             {
@@ -144,19 +146,19 @@ namespace ShaiRandom.Generators
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateA = x ^ x >> 27;
+                rng.StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateB = x ^ x >> 27;
+                rng.StateB = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateC = x ^ x >> 27;
+                rng.StateC = x ^ x >> 27;
             }
         }
 

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -63,7 +63,7 @@ namespace ShaiRandom.Generators
          */
         public Xoshiro256StarStarRandom(ulong seed)
         {
-            Seed(seed);
+            SetSeed(this, seed);
         }
 
         /**
@@ -156,7 +156,9 @@ namespace ShaiRandom.Generators
          * different for every different {@code seed}).
          * @param seed the initial seed; may be any long
          */
-        public override void Seed(ulong seed)
+        public override void Seed(ulong seed) => SetSeed(this, seed);
+
+        private static void SetSeed(Xoshiro256StarStarRandom rng, ulong seed)
         {
             unchecked
             {
@@ -165,25 +167,25 @@ namespace ShaiRandom.Generators
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateA = x ^ x >> 27;
+                rng.StateA = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateB = x ^ x >> 27;
+                rng.StateB = x ^ x >> 27;
                 x = (seed += 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                StateC = x ^ x >> 27;
+                rng.StateC = x ^ x >> 27;
                 x = (seed + 0x9E3779B97F4A7C15UL);
                 x ^= x >> 27;
                 x *= 0x3C79AC492BA7B653UL;
                 x ^= x >> 33;
                 x *= 0x1C69B3F74AC4AE35UL;
-                _d = x ^ x >> 27;
+                rng._d = x ^ x >> 27;
             }
         }
 

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace ShaiRandom.Generators
 {
@@ -7,7 +6,7 @@ namespace ShaiRandom.Generators
     /// It's an AbstractRandom with 4 states, implementing a known-rather-good algorithm, more here later.
     /// </summary>
     [Serializable]
-    public class Xoshiro256StarStarRandom : AbstractRandom, IEquatable<Xoshiro256StarStarRandom?>
+    public class Xoshiro256StarStarRandom : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "XSSR" .
@@ -242,17 +241,5 @@ namespace ShaiRandom.Generators
             StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
             return this;
         }
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as Xoshiro256StarStarRandom);
-
-        /// <inheritdoc />
-        public bool Equals(Xoshiro256StarStarRandom? other) => other != null && StateA == other.StateA && StateB == other.StateB && StateC == other.StateC && StateD == other.StateD;
-
-        /// <inheritdoc />
-        public override int GetHashCode() => HashCode.Combine(StateA, StateB, StateC, _d);
-
-        public static bool operator ==(Xoshiro256StarStarRandom? left, Xoshiro256StarStarRandom? right) => EqualityComparer<Xoshiro256StarStarRandom>.Default.Equals(left, right);
-        public static bool operator !=(Xoshiro256StarStarRandom? left, Xoshiro256StarStarRandom? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -12,8 +12,8 @@ namespace ShaiRandom.Wrappers
     /// ReversingWrapper will permit calls to its Skip, and they will also go in reverse. The most common use for this would be to run
     /// the wrapped generator forward and track the number of calls made, then run the ReversingWrapper by the same number of calls
     /// (potentially using Skip(), if supported) to revert the state to its original value. This is more convenient for the usage where
-    /// you use <see cref="EnhancedRandomExtensions.Shuffle{T}(IEnhancedRandom, T[])"/> with both the wrapped generator and wrapper, since they will use the same amount of
-    /// calls, and this will even un-shuffle the array (restoring it to its order before the shuffle).
+    /// you use <see cref="EnhancedRandomExtensions.Shuffle{T}(IEnhancedRandom, Span&lt;T&gt;)"/> or other span variants with both the wrapped
+    /// generator and wrapper, since they will use the same amount of calls, and this will even un-shuffle the array (restoring it to its order before the shuffle).
     /// </summary>
     [Serializable]
     public class ReversingWrapper : AbstractRandom, IEquatable<ReversingWrapper?>

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using ShaiRandom.Generators;
 
 namespace ShaiRandom.Wrappers
@@ -12,11 +11,11 @@ namespace ShaiRandom.Wrappers
     /// ReversingWrapper will permit calls to its Skip, and they will also go in reverse. The most common use for this would be to run
     /// the wrapped generator forward and track the number of calls made, then run the ReversingWrapper by the same number of calls
     /// (potentially using Skip(), if supported) to revert the state to its original value. This is more convenient for the usage where
-    /// you use <see cref="EnhancedRandomExtensions.Shuffle{T}(IEnhancedRandom, Span&lt;T&gt;)"/> or other span variants with both the wrapped
+    /// you use <see cref="EnhancedRandomExtensions.Shuffle{T}(IEnhancedRandom, Span&lt;T&gt;)"/> or other Shuffle variants with both the wrapped
     /// generator and wrapper, since they will use the same amount of calls, and this will even un-shuffle the array (restoring it to its order before the shuffle).
     /// </summary>
     [Serializable]
-    public class ReversingWrapper : AbstractRandom, IEquatable<ReversingWrapper?>
+    public class ReversingWrapper : AbstractRandom
     {
         /// <summary>
         /// The identifying tag here is "R" , which is an invalid length to indicate the tag is not meant to be registered or used on its own.
@@ -92,17 +91,8 @@ namespace ShaiRandom.Wrappers
         public override ulong PreviousULong() => Wrapped.NextULong();
 
         /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as ReversingWrapper);
-
-        /// <inheritdoc />
-        public bool Equals(ReversingWrapper? other) => other != null && EqualityComparer<IEnhancedRandom>.Default.Equals(Wrapped, other.Wrapped);
-
-        /// <inheritdoc />
         public override ulong SelectState(int selection) => Wrapped.SelectState(selection);
         /// <inheritdoc />
         public override void SetSelectedState(int selection, ulong value) => Wrapped.SetSelectedState(selection, value);
-
-        public static bool operator ==(ReversingWrapper? left, ReversingWrapper? right) => EqualityComparer<ReversingWrapper>.Default.Equals(left, right);
-        public static bool operator !=(ReversingWrapper? left, ReversingWrapper? right) => !(left == right);
     }
 }

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -51,7 +51,7 @@ namespace ShaiRandom.Wrappers
         public ReversingWrapper(IEnhancedRandom wrapping)
         {
             if (!wrapping.SupportsPrevious)
-                throw new ArgumentException($"The AbstractRandom to wrap must support PreviousULong(), and {nameof(wrapping)} does not.", nameof(wrapping));
+                throw new ArgumentException($"The AbstractRandom to wrap must support PreviousULong().", nameof(wrapping));
             Wrapped = wrapping;
         }
 

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -21,22 +21,37 @@ namespace ShaiRandom.Wrappers
         /// The identifying tag here is "R" , which is an invalid length to indicate the tag is not meant to be registered or used on its own.
         /// </summary>
         public override string Tag => "R";
+
+        /// <summary>
+        /// The ShaiRandom generator being wrapped, which must never be null.
+        /// </summary>
         public IEnhancedRandom Wrapped { get; set; }
 
+        /// <summary>
+        /// Creates a new ReversingWrapper around a new <see cref="FourWheelRandom"/> generator with a random initial
+        /// state.
+        /// </summary>
         public ReversingWrapper()
         {
             Wrapped = new FourWheelRandom();
         }
 
+        /// <summary>
+        /// Creates a new ReversingWrapper around a new <see cref="FourWheelRandom"/> generator seeded with the given
+        /// value.
+        /// </summary>
         public ReversingWrapper(ulong seed)
         {
             Wrapped = new FourWheelRandom(seed);
         }
 
+        /// <summary>
+        /// Creates a new ReversingWrapper around the given generator, which must support <see cref="IEnhancedRandom.PreviousULong"/>.
+        /// </summary>
         public ReversingWrapper(IEnhancedRandom wrapping)
         {
             if (!wrapping.SupportsPrevious)
-                throw new NotSupportedException($"The AbstractRandom to wrap must support PreviousULong(), and {nameof(wrapping)} does not.");
+                throw new ArgumentException($"The AbstractRandom to wrap must support PreviousULong(), and {nameof(wrapping)} does not.", nameof(wrapping));
             Wrapped = wrapping;
         }
 

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using ShaiRandom.Generators;
+﻿using ShaiRandom.Generators;
 using Troschuetz.Random;
 
 namespace ShaiRandom.Wrappers
@@ -14,7 +12,7 @@ namespace ShaiRandom.Wrappers
     /// and are implemented in terms of IEnhancedRandom methods.
     /// </remarks>
     [System.Serializable]
-    public class TRGeneratorWrapper : AbstractRandom, IGenerator, IEquatable<TRGeneratorWrapper?>
+    public class TRGeneratorWrapper : AbstractRandom, IGenerator
     {
         /// <summary>
         /// The identifying tag here is "T" , which is an invalid length to indicate the tag is not meant to be registered or used on its own.
@@ -107,15 +105,5 @@ namespace ShaiRandom.Wrappers
         bool IGenerator.Reset() => false;
         bool IGenerator.Reset(uint seed) => false;
         #endregion
-
-        /// <inheritdoc />
-        public override bool Equals(object? obj) => Equals(obj as TRGeneratorWrapper);
-        /// <inheritdoc />
-        public bool Equals(TRGeneratorWrapper? other) => other != null && EqualityComparer<IEnhancedRandom>.Default.Equals(Wrapped, other.Wrapped);
-
-        public static bool operator ==(TRGeneratorWrapper? left, TRGeneratorWrapper? right) => EqualityComparer<TRGeneratorWrapper>.Default.Equals(left, right);
-        public static bool operator !=(TRGeneratorWrapper? left, TRGeneratorWrapper? right) => !(left == right);
-
-
     }
 }

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -20,7 +20,7 @@ namespace ShaiRandom.Wrappers
         public override string Tag => "T";
 
         /// <summary>
-        /// The wrapped AbstractRandom, which must never be null.
+        /// The wrapped RNG, which must never be null.
         /// </summary>
         public IEnhancedRandom Wrapped { get; set; }
 


### PR DESCRIPTION
# Changes
- Implementation/overrides of `IEquatable<T>`, `Equals(object)`, `GetHashCode()`, `operator==`, and `operator!=` have been removed from all generators/classes
    - Attempts to maintain consistency with C# guidelines on these topics (see below discussion); also eliminates warnings
    - These implementations also appeared to be equivalent to calling `AreEqual` (now `Matches`) in all cases except for `KnownSeriesRandom`
- Renamed `AreEqual` to `Matches`, and modified it to be an IEnhancedRandom extension method
- `AbstractRandom` constructor taking no parameters has been removed (it was never called and was one of the more potentially dangerous instances of virtual method calls in a constructor)
-  Modified all generators to avoid calling `Seed(ulong)`/`SetState` (virtual methods) from their constructor
    - See below discussions; eliminates warnings
    - Effectively, in these cases the contents of the `Seed` function was moved out into a private, static function, which both `Seed(ulong)` and the constructor call.  No functionality should change.
- Added miscellaneous documentation
    - No more missing documentation warnings! (Although a lot of the documentation still needs to be un-javadoc'ed)
- Tweaked some exception types to be more consistent with conventions
    - NotSupportedException in constructor of `ReversingWrapper` became an `ArgumentException`, mostly
- Fixed all remaining compiler/analyzer warnings (via the changes above)
    - Analyzers (but not the compiler) still complain about unused variables in `Scratch.cs`, but I didn't want to touch those

# End State/Goal
The goals here are fairly simple:
1. Eliminate compiler and analyzer warnings
2. Ensure documentation and error handling is consistent
3. Adhere to C# conventions/guidelines wherever possible

Unfortunately, the implementation of these goals is more complex than it may seem, and in some cases depends on some interpretation of guidelines beyond strictly what is written.  I'll outline the changes and why I made them below in an attempt to document the decisions to this end.

## Removed Virtual Method Calls in Constructors
A number of generators, including `AbstractRandom` and a few others, were calling `Seed(ulong)` (a virtual method) from their constructors.  Calling virtual methods from a constructor is, in general, bad practice in C#; why this is so is discussed fairly clearly [here](https://docs.microsoft.com/en-us/archive/blogs/ericlippert/why-do-initializers-run-in-the-opposite-order-as-constructors-part-one) and [here](https://www.jetbrains.com/help/rider/VirtualMemberCallInConstructor.html).  The short version is that, if the most derived implementation of a virtual method is, directly or indirectly, depending on state of either the derived or base class, undesirable behavior can occur if that method is called from a constructor, since the order in which initializers and constructors are called from base classes through derived classes is not necessarily intuitive in C#.

Interestingly, none of the `SetState` or `Seed` implementations that were being called from constructors _actually_ made any assumptions about the state of the generator (base or otherwise); they all appear to initialize state without any assumptions of its current value.  Therefore, provided all the implementations were to stay exactly as they are, it would have been safe to simply suppress the warnings.  However, I elected to modify the code to avoid them for three main reasons:

1. It could be possible to change the implementation from "safe" to "unsafe" with very subtle modifications, which could produce non-obvious results in the future
2. The `AbstractRandom` constructor that called a virtual function (that is only implemented in the derived classes) could be particularly dangerous for a user, if they are extending `AbstractRandom` and do not realize the constraints that thus apply (although the constructor was never actually used in `ShaiRandom` code)
3. Modifying the code to avoid the calls was simple and easy

The method of avoiding the virtual calls was trivial; I simply removed the `AbstractRandom` constructor that took a seed value, and moved the implementation of `Seed` in derived generators to a static, private function, which both the constructor and the `Seed(ulong)` implementation now call.  Since a user can no longer directly override something that is called from a constructor in any cases, this prevents the potential for introducing subtle bugs to that end.

## Removed IEquatable, Equals, GetHashCode, and Related Implementations
Equality (as defined by built-in C# interfaces) is a fairly nuanced topic, that seems to require some advanced understanding of C#, and arguably some interpretation of Microsoft's C# guidelines, in order to fully represent.  Some good reading can be found in Microsoft's guidelines [here](https://docs.microsoft.com/en-us/dotnet/api/system.object.equals?view=net-6.0), [here](https://docs.microsoft.com/en-us/dotnet/api/system.iequatable-1?view=net-6.0), and [here](https://docs.microsoft.com/en-us/dotnet/api/system.object.gethashcode?view=net-6.0#System_Object_GetHashCode), particularly in the "Remarks", "Notes to Implementors", and "Notes to Inheritors" sections.  Some relevant excerpts from these pages:

> Most reference types must not overload the equality operator, even if they override Equals. However, if you are implementing a reference type that is intended to have value semantics, such as a complex number type, you must override the equality operator.

> You should not override Equals on a mutable reference type. This is because overriding Equals requires that you also override the GetHashCode method, as discussed in the previous section. This means that the hash code of an instance of a mutable reference type can change during its lifetime, which can cause the object to be lost in a hash table.

> If you implement IEquatable<T>, you should also override the base class implementations of Equals(Object) and GetHashCode() so that their behavior is consistent with that of the Equals(T) method.

> In general, for mutable reference types, you should override GetHashCode() only if:
> 
> - You can compute the hash code from fields that are not mutable; or
> - You can ensure that the hash code of a mutable object does not change while the object is contained in a collection that relies on its hash code.
>
> Otherwise, you might think that the mutable object is lost in the hash table. If you do choose to override GetHashCode() for a mutable reference type, your documentation should make it clear that users of your type should not modify object values while the object is stored in a hash table.

The core of most of the issues surrounding equality is derived from why equality interfaces are built into C#, and how map structures such as `HashSet` and `Dictionary` idiomatically deal with keys.  Although it can be customized via custom `IEqualityComparer` instances, by default, `Dictionary` and `HashSet` use `IEqualityComparer<T>.Default` to do their comparisons, which means they deal with keys in the following way:
1. Keys are hashed using the `object.GetHashCode` function (which can be overridden by derived classes)
2. Keys are compared for equality using their `IEquatable<T>` implementation if they have one; if not, their `object.Equals(object)` implementation is used (which can be overridden by derived classes)

Because of this, equality functions (no matter which interface or method they're implemented through) and the GetHashCode function are related and typically must be implemented together.  Primarily, for structures to function properly in a hash map type container by default, you _must_ ensure that, if two objects produce the `true` via `Equals`, they must also produce the same hash code (though the inverse need not be the case).  The implementation of `GetHashCode`, in turn, must _not_ allow the hash code to change after an object has been added to a hash table, otherwise the object will become lost.  This is why it is best practice to _not_ use mutable values in the calculation of the hash code; and since `GetHashCode` must produce the same hash code for things that are equal according to `Equals`, it is also best practice to not implement Equals either for mutable reference types.

Therefore, in an effort to adhere to C# guidelines, and to ensure that no unexpected weirdness can happen if a generator is used in a `Dictionary` or `HashSet` for whatever reason, I have removed the implementation of equality-related interface and functions (with the exception of `AreEqual`, which implements no particular interface) from generators and the like (all of which are mutable reference types).  I also renamed `AreEqual` to `Matches` and modified it to be an extension method, since by and large it applies to any generic `IEnhancedRandom`, not just to `AbstractRandom` implementations.  The `Matches` name relates to no particular convention other than my own; its aim is simply to stay away from the complex `Equals` terminology but still succinctly convey what is happening.  The [primitives library](https://github.com/thesadrogue/TheSadRogue.Primitives/blob/master/TheSadRogue.Primitives/IMatchable.cs) used by SadConsole and GoRogue, for instance, has used this quite successfully, and in fact went so far as to add an interface for the concept.

Removal of the equality-related items shouldn't produce much tangible change in behavior; in fact, the `Equals` implementations appeared to be equivalent to calling `Matches` already, for all cases except for `KnownSeriesRandom` (where `Matches` compares indices but not the series themselves).  It is of course possible to implement a custom comparison of some sort for `KnownSeriesRandom` to remedy this, however in all honesty, I can't see many use cases for comparing `KnownSeriesRandom` generators to each other that don't involve testing and would probably be better served by a custom equality comparer.