### PR TITLE
KnownSeriesRandom Fixes and Unit Tests

### DIFF
--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -67,6 +67,9 @@ namespace ShaiRandom.UnitTests
             Assert.Equal(value, generatorFunc(value, value - 1));
             // Allowed range: [value - 1, value]
             Assert.Equal(value, generatorFunc(value, value - 2));
+
+            Assert.Throws<ArgumentException>(() => generatorFunc(value - 1, value - 2));
+            Assert.Throws<ArgumentException>(() => generatorFunc(value + 1, value));
         }
 
         private static void TestUpperBoundIntFunction<T>(Func<T, T> upperBoundFunc, Func<T, T, T> dualBoundFunc)
@@ -112,6 +115,9 @@ namespace ShaiRandom.UnitTests
             Assert.Equal(value, generatorFunc(value, value));
             // Allowed range: Allowed range: (value - 0.1, value]
             Assert.Equal(value, generatorFunc(value, value - 0.1));
+
+            Assert.Throws<ArgumentException>(() => generatorFunc(value - 0.1, value - 0.2));
+            Assert.Throws<ArgumentException>(() => generatorFunc(value + 0.1, value));
         }
 
         private static void TestUpperBoundFloatingFunction<T>(Func<T, T> upperBoundFunc, Func<T, T, T> dualBoundFunc)

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -47,12 +47,12 @@ namespace ShaiRandom.UnitTests
         [Fact]
         public void NextDoubleLowerBound()
         {
-            double value = LowerValue;
+            double value = UpperValue;
 
-            Assert.Equal(value, _lowerRNG.NextDouble(value + 0.1));
-            Assert.Equal(value, _lowerRNG.NextDouble(value, value + 0.1));
+            Assert.Equal(value, _upperRNG.NextDouble(value + 0.1));
+            Assert.Equal(value, _upperRNG.NextDouble(value, value + 0.1));
 
-            Assert.Throws<ArgumentException>(() => _lowerRNG.NextDouble(value + 0.1, value + 0.2));
+            Assert.Throws<ArgumentException>(() => _upperRNG.NextDouble(value + 0.1, value + 0.2));
         }
 
         [Fact]
@@ -104,14 +104,14 @@ namespace ShaiRandom.UnitTests
         [Fact]
         public void NextIntCrossedBounds()
         {
-            int value = LowerValue;
+            int value = UpperValue;
 
             // Allowed range: value
-            Assert.Equal(value, _lowerRNG.NextInt(value, value));
+            Assert.Equal(value, _upperRNG.NextInt(value, value));
             // Allowed range: value
-            Assert.Equal(value, _lowerRNG.NextInt(value, value - 1));
+            Assert.Equal(value, _upperRNG.NextInt(value, value - 1));
             // Allowed range: [value - 1, value]
-            Assert.Equal(value, _lowerRNG.NextInt(value, value - 2));
+            Assert.Equal(value, _upperRNG.NextInt(value, value - 2));
         }
 
         [Fact]
@@ -126,5 +126,6 @@ namespace ShaiRandom.UnitTests
             Assert.Throws<ArgumentException>(() => _upperRNG.NextInt(value - 1, value));
         }
         #endregion
+
     }
 }

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using ShaiRandom.Generators;
+using Xunit;
+
+namespace ShaiRandom.UnitTests
+{
+    public class KnownSeriesRandomTests
+    {
+        private const int LowerInt = 0;
+        private const int UpperInt = 10;
+
+        [Fact]
+        public void NextIntLowerBound()
+        {
+            var rng = new KnownSeriesRandom(new[] { LowerInt });
+
+            Assert.Equal(LowerInt, rng.NextInt(LowerInt + 1));
+            Assert.Equal(LowerInt, rng.NextInt(LowerInt, LowerInt + 1));
+
+            Assert.Throws<ArgumentException>(() => rng.NextInt(LowerInt + 1, LowerInt + 2));
+        }
+        
+        [Fact]
+        public void NextIntUpperBound()
+        {
+            var rng = new KnownSeriesRandom(new[] { UpperInt });
+
+            Assert.Equal(UpperInt, rng.NextInt(UpperInt + 1));
+            Assert.Equal(UpperInt, rng.NextInt(UpperInt, UpperInt + 1));
+
+            Assert.Throws<ArgumentException>(() => rng.NextInt(UpperInt));
+            Assert.Throws<ArgumentException>(() => rng.NextInt(UpperInt - 1, UpperInt));
+        }
+    }
+}

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -1,35 +1,102 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using ShaiRandom.Generators;
 using Xunit;
 
 namespace ShaiRandom.UnitTests
 {
+    [SuppressMessage("ReSharper", "UselessBinaryOperation")]
     public class KnownSeriesRandomTests
     {
-        private const int LowerInt = 0;
-        private const int UpperInt = 10;
+        private const int LowerValue = 0;
+        private const int UpperValue = 10;
 
+        private KnownSeriesRandom _lowerRNG = new KnownSeriesRandom(
+            new []{LowerValue},
+            new []{(uint)LowerValue},
+            new []{(double)LowerValue},
+            byteSeries: new []{(byte)LowerValue},
+            floatSeries: new []{(float)LowerValue},
+            longSeries: new []{(long)LowerValue},
+            ulongSeries: new []{(ulong)LowerValue}
+        );
+
+        private KnownSeriesRandom _upperRNG = new KnownSeriesRandom(
+            new []{UpperValue},
+            new []{(uint)UpperValue},
+            new []{(double)UpperValue},
+            byteSeries: new []{(byte)UpperValue},
+            floatSeries: new []{(float)UpperValue},
+            longSeries: new []{(long)UpperValue},
+            ulongSeries: new []{(ulong)UpperValue}
+        );
+
+        #region Floating-Point Types
+        [Fact]
+        public void NextDoubleLowerBound()
+        {
+            double value = LowerValue;
+
+            Assert.Equal(value, _lowerRNG.NextDouble(value + 0.1));
+            Assert.Equal(value, _lowerRNG.NextDouble(value, value + 0.1));
+
+            Assert.Throws<ArgumentException>(() => _lowerRNG.NextDouble(value + 0.1, value + 0.2));
+        }
+
+        [Fact]
+        public void NextDoubleCrossedBounds()
+        {
+            double value = LowerValue;
+
+            Assert.Equal(value, _lowerRNG.NextDouble(value, value));
+            Assert.Equal(value, _lowerRNG.NextDouble(value, value - 0.1));
+        }
+
+        [Fact]
+        public void NextDoubleUpperBound()
+        {
+            double value = UpperValue;
+
+            Assert.Equal(value, _upperRNG.NextDouble(value + 0.1));
+            Assert.Equal(value, _upperRNG.NextDouble(value, value + 0.1));
+
+            Assert.Throws<ArgumentException>(() => _upperRNG.NextDouble(value));
+            Assert.Throws<ArgumentException>(() => _upperRNG.NextDouble(value - 0.1, value));
+        }
+        #endregion
+
+        #region Integer Types
         [Fact]
         public void NextIntLowerBound()
         {
-            var rng = new KnownSeriesRandom(new[] { LowerInt });
+            int value = LowerValue;
 
-            Assert.Equal(LowerInt, rng.NextInt(LowerInt + 1));
-            Assert.Equal(LowerInt, rng.NextInt(LowerInt, LowerInt + 1));
+            Assert.Equal(value, _lowerRNG.NextInt(value + 1));
+            Assert.Equal(value, _lowerRNG.NextInt(value, value + 1));
 
-            Assert.Throws<ArgumentException>(() => rng.NextInt(LowerInt + 1, LowerInt + 2));
+            Assert.Throws<ArgumentException>(() => _lowerRNG.NextInt(value + 1, value + 2));
         }
-        
+
+        [Fact]
+        public void NextIntCrossedBounds()
+        {
+            int value = LowerValue;
+
+            Assert.Equal(value, _lowerRNG.NextInt(value, value));
+            Assert.Equal(value, _lowerRNG.NextInt(value, value - 1));
+        }
+
         [Fact]
         public void NextIntUpperBound()
         {
-            var rng = new KnownSeriesRandom(new[] { UpperInt });
+            int value = UpperValue;
 
-            Assert.Equal(UpperInt, rng.NextInt(UpperInt + 1));
-            Assert.Equal(UpperInt, rng.NextInt(UpperInt, UpperInt + 1));
+            Assert.Equal(value, _upperRNG.NextInt(value + 1));
+            Assert.Equal(value, _upperRNG.NextInt(value, value + 1));
 
-            Assert.Throws<ArgumentException>(() => rng.NextInt(UpperInt));
-            Assert.Throws<ArgumentException>(() => rng.NextInt(UpperInt - 1, UpperInt));
+            Assert.Throws<ArgumentException>(() => _upperRNG.NextInt(value));
+            Assert.Throws<ArgumentException>(() => _upperRNG.NextInt(value - 1, value));
         }
+        #endregion
     }
 }

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -11,6 +11,7 @@ namespace ShaiRandom.UnitTests
         private const int LowerValue = 0;
         private const int UpperValue = 10;
 
+        private static readonly float s_floatAdjust = MathF.Pow(2f, -24f);
         private static readonly double s_doubleCloseTo1 = 1 - Math.Pow(2, -53);
 
         private readonly KnownSeriesRandom _lowerRNG = new KnownSeriesRandom(
@@ -31,6 +32,16 @@ namespace ShaiRandom.UnitTests
             floatSeries: new []{(float)UpperValue},
             longSeries: new []{(long)UpperValue},
             ulongSeries: new []{(ulong)UpperValue}
+        );
+
+        private readonly KnownSeriesRandom _unboundedRNG = new KnownSeriesRandom(
+            new []{int.MinValue, int.MaxValue},
+            new []{uint.MinValue, uint.MaxValue},
+            new []{0.0, 1.0 - s_doubleCloseTo1},
+            byteSeries: new []{byte.MinValue, byte.MaxValue},
+            floatSeries: new []{0.0f, 1.0f - s_floatAdjust},
+            longSeries: new []{long.MinValue, long.MaxValue},
+            ulongSeries: new []{ulong.MinValue, ulong.MaxValue}
         );
 
         #region Double
@@ -79,52 +90,71 @@ namespace ShaiRandom.UnitTests
         }
         #endregion
 
+        #region Template Tests
+
+        private void TestUnboundedIntFunction<T>(Func<T> unboundedGenFunc)
+        {
+            T minValue = (T)typeof(T).GetField("MinValue")!.GetValue(null)!;
+            T maxValue = (T)typeof(T).GetField("MaxValue")!.GetValue(null)!;
+
+            Assert.Equal(minValue, unboundedGenFunc());
+            Assert.Equal(maxValue,unboundedGenFunc());
+        }
+
+        private static void TestLowerBoundIntFunction<T>(Func<T, T> upperBoundFunc, Func<T, T, T> dualBoundFunc)
+            where T : IConvertible
+        {
+            // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
+            dynamic value = (T)Convert.ChangeType(LowerValue, typeof(T));
+
+            Assert.Equal(value, upperBoundFunc(value + 1));
+            Assert.Equal(value, dualBoundFunc(value, value + 1));
+
+            Assert.Throws<ArgumentException>(() => dualBoundFunc(value + 1, value + 2));
+        }
+
+        private static void TestCrossedBoundIntFunction<T>(Func<T, T, T> generatorFunc)
+            where T : IConvertible
+        {
+            // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
+            dynamic value = (T)Convert.ChangeType(UpperValue, typeof(T));
+
+            // Allowed range: value
+            Assert.Equal(value, generatorFunc(value, value));
+            // Allowed range: value
+            Assert.Equal(value, generatorFunc(value, value - 1));
+            // Allowed range: [value - 1, value]
+            Assert.Equal(value, generatorFunc(value, value - 2));
+        }
+
+        private static void TestUpperBoundIntFunction<T>(Func<T, T> upperBoundFunc, Func<T, T, T> dualBoundFunc)
+            where T : IConvertible
+        {
+            // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
+            dynamic value = (T)Convert.ChangeType(UpperValue, typeof(T));
+
+            Assert.Equal(value, upperBoundFunc(value + 1));
+            Assert.Equal(value, dualBoundFunc(value, value + 1));
+
+            Assert.Throws<ArgumentException>(() => upperBoundFunc(value));
+            Assert.Throws<ArgumentException>(() => dualBoundFunc(value - 1, value));
+        }
+        #endregion
+
         #region Int
 
         [Fact]
-        public void NextIntUnbounded()
-        {
-            var rng = new KnownSeriesRandom(new[] { int.MinValue, int.MaxValue });
-
-            Assert.Equal(int.MinValue, rng.NextInt());
-            Assert.Equal(int.MaxValue,rng.NextInt());
-        }
+        public void NextIntUnbounded() => TestUnboundedIntFunction(_unboundedRNG.NextInt);
 
         [Fact]
-        public void NextIntLowerBound()
-        {
-            int value = LowerValue;
-
-            Assert.Equal(value, _lowerRNG.NextInt(value + 1));
-            Assert.Equal(value, _lowerRNG.NextInt(value, value + 1));
-
-            Assert.Throws<ArgumentException>(() => _lowerRNG.NextInt(value + 1, value + 2));
-        }
+        public void NextIntLowerBound() => TestLowerBoundIntFunction<int>(_lowerRNG.NextInt, _lowerRNG.NextInt);
 
         [Fact]
-        public void NextIntCrossedBounds()
-        {
-            int value = UpperValue;
-
-            // Allowed range: value
-            Assert.Equal(value, _upperRNG.NextInt(value, value));
-            // Allowed range: value
-            Assert.Equal(value, _upperRNG.NextInt(value, value - 1));
-            // Allowed range: [value - 1, value]
-            Assert.Equal(value, _upperRNG.NextInt(value, value - 2));
-        }
+        public void NextIntCrossedBounds() => TestCrossedBoundIntFunction<int>(_upperRNG.NextInt);
 
         [Fact]
-        public void NextIntUpperBound()
-        {
-            int value = UpperValue;
+        public void NextIntUpperBound() => TestUpperBoundIntFunction<int>(_upperRNG.NextInt, _upperRNG.NextInt);
 
-            Assert.Equal(value, _upperRNG.NextInt(value + 1));
-            Assert.Equal(value, _upperRNG.NextInt(value, value + 1));
-
-            Assert.Throws<ArgumentException>(() => _upperRNG.NextInt(value));
-            Assert.Throws<ArgumentException>(() => _upperRNG.NextInt(value - 1, value));
-        }
         #endregion
 
     }

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -283,9 +283,6 @@ namespace ShaiRandom.UnitTests
 
             // Check that single bound function accepts only range (0.0, outer).
             // outer == 0.0 is a special case which always returns 0.0.
-            // TODO: This outer == 0.0 behavior is not documented; either the documentation should be updated to reflect
-            // that this is the expected behavior, or the documentation should reflect it's undefined behavior and the
-            // test case for it should be removed.
             Assert.Equal(value, outerBound(value + pointOne));   // Allowed range: (0.0, value + 0.1)
             Assert.Equal(zero, zeroOuterBound(zero));            // Allowed range: 0
 
@@ -296,7 +293,6 @@ namespace ShaiRandom.UnitTests
 
             // Check that double bound function accepts only range (inner, outer), even if outer < inner.
             // outer == inner is a special case which always returns inner.
-            // TODO: Ditto above on the inner == outer behavior
             Assert.Equal(value, dualBound(value - pointOne, value + pointOne)); // Allowed range: (value - 0.1, value + 0.1)
             Assert.Equal(value, dualBound(value, value));                       // Allowed range: value
 

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -11,7 +11,9 @@ namespace ShaiRandom.UnitTests
         private const int LowerValue = 0;
         private const int UpperValue = 10;
 
-        private KnownSeriesRandom _lowerRNG = new KnownSeriesRandom(
+        private static readonly double s_doubleCloseTo1 = 1 - Math.Pow(2, -53);
+
+        private readonly KnownSeriesRandom _lowerRNG = new KnownSeriesRandom(
             new []{LowerValue},
             new []{(uint)LowerValue},
             new []{(double)LowerValue},
@@ -21,7 +23,7 @@ namespace ShaiRandom.UnitTests
             ulongSeries: new []{(ulong)LowerValue}
         );
 
-        private KnownSeriesRandom _upperRNG = new KnownSeriesRandom(
+        private readonly KnownSeriesRandom _upperRNG = new KnownSeriesRandom(
             new []{UpperValue},
             new []{(uint)UpperValue},
             new []{(double)UpperValue},
@@ -31,7 +33,17 @@ namespace ShaiRandom.UnitTests
             ulongSeries: new []{(ulong)UpperValue}
         );
 
-        #region Floating-Point Types
+        #region Double
+
+        [Fact]
+        public void NextDoubleUnbounded()
+        {
+            var rng = new KnownSeriesRandom(doubleSeries: new[] { 0.0, s_doubleCloseTo1 });
+
+            Assert.Equal(0.0, rng.NextDouble());
+            Assert.Equal(s_doubleCloseTo1, rng.NextDouble());
+        }
+
         [Fact]
         public void NextDoubleLowerBound()
         {
@@ -48,7 +60,9 @@ namespace ShaiRandom.UnitTests
         {
             double value = LowerValue;
 
+            // Allowed range: value
             Assert.Equal(value, _lowerRNG.NextDouble(value, value));
+            // Allowed range: (value - 0.1, value]
             Assert.Equal(value, _lowerRNG.NextDouble(value, value - 0.1));
         }
 
@@ -65,7 +79,17 @@ namespace ShaiRandom.UnitTests
         }
         #endregion
 
-        #region Integer Types
+        #region Int
+
+        [Fact]
+        public void NextIntUnbounded()
+        {
+            var rng = new KnownSeriesRandom(new[] { int.MinValue, int.MaxValue });
+
+            Assert.Equal(int.MinValue, rng.NextInt());
+            Assert.Equal(int.MaxValue,rng.NextInt());
+        }
+
         [Fact]
         public void NextIntLowerBound()
         {
@@ -82,8 +106,12 @@ namespace ShaiRandom.UnitTests
         {
             int value = LowerValue;
 
+            // Allowed range: value
             Assert.Equal(value, _lowerRNG.NextInt(value, value));
+            // Allowed range: value
             Assert.Equal(value, _lowerRNG.NextInt(value, value - 1));
+            // Allowed range: [value - 1, value]
+            Assert.Equal(value, _lowerRNG.NextInt(value, value - 2));
         }
 
         [Fact]

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -8,30 +8,19 @@ namespace ShaiRandom.UnitTests
     [SuppressMessage("ReSharper", "UselessBinaryOperation")]
     public class KnownSeriesRandomTests
     {
-        private const int LowerValue = 0;
-        private const int UpperValue = 10;
+        private const int ReturnedValue = 10;
 
         private static readonly float s_floatAdjust = MathF.Pow(2f, -24f);
         private static readonly double s_doubleCloseTo1 = 1 - Math.Pow(2, -53);
 
-        private readonly KnownSeriesRandom _lowerRNG = new KnownSeriesRandom(
-            new []{LowerValue},
-            new []{(uint)LowerValue},
-            new []{(double)LowerValue},
-            byteSeries: new []{(byte)LowerValue},
-            floatSeries: new []{(float)LowerValue},
-            longSeries: new []{(long)LowerValue},
-            ulongSeries: new []{(ulong)LowerValue}
-        );
-
-        private readonly KnownSeriesRandom _upperRNG = new KnownSeriesRandom(
-            new []{UpperValue},
-            new []{(uint)UpperValue},
-            new []{(double)UpperValue},
-            byteSeries: new []{(byte)UpperValue},
-            floatSeries: new []{(float)UpperValue},
-            longSeries: new []{(long)UpperValue},
-            ulongSeries: new []{(ulong)UpperValue}
+        private readonly KnownSeriesRandom _boundedRNG = new KnownSeriesRandom(
+            new []{ReturnedValue},
+            new []{(uint)ReturnedValue},
+            new []{(double)ReturnedValue},
+            byteSeries: new []{(byte)ReturnedValue},
+            floatSeries: new []{(float)ReturnedValue},
+            longSeries: new []{(long)ReturnedValue},
+            ulongSeries: new []{(ulong)ReturnedValue}
         );
 
         private readonly KnownSeriesRandom _unboundedRNG = new KnownSeriesRandom(
@@ -44,55 +33,53 @@ namespace ShaiRandom.UnitTests
             ulongSeries: new []{ulong.MinValue, ulong.MaxValue}
         );
 
-        #region Double
-
+        #region Test Double
         [Fact]
         public void NextDoubleUnbounded()
         {
-            var rng = new KnownSeriesRandom(doubleSeries: new[] { 0.0, s_doubleCloseTo1 });
+            var specialRng = new KnownSeriesRandom(doubleSeries: new[] { 0.0, s_doubleCloseTo1 });
 
-            Assert.Equal(0.0, rng.NextDouble());
-            Assert.Equal(s_doubleCloseTo1, rng.NextDouble());
+            Assert.Equal(0.0, specialRng.NextDouble());
+            Assert.Equal(s_doubleCloseTo1, specialRng.NextDouble());
         }
 
         [Fact]
         public void NextDoubleLowerBound()
         {
-            double value = UpperValue;
+            double value = ReturnedValue;
 
-            Assert.Equal(value, _upperRNG.NextDouble(value + 0.1));
-            Assert.Equal(value, _upperRNG.NextDouble(value, value + 0.1));
+            Assert.Equal(value, _boundedRNG.NextDouble(value + 0.1));
+            Assert.Equal(value, _boundedRNG.NextDouble(value, value + 0.1));
 
-            Assert.Throws<ArgumentException>(() => _upperRNG.NextDouble(value + 0.1, value + 0.2));
+            Assert.Throws<ArgumentException>(() => _boundedRNG.NextDouble(value + 0.1, value + 0.2));
         }
 
-        [Fact]
-        public void NextDoubleCrossedBounds()
-        {
-            double value = LowerValue;
-
-            // Allowed range: value
-            Assert.Equal(value, _lowerRNG.NextDouble(value, value));
-            // Allowed range: (value - 0.1, value]
-            Assert.Equal(value, _lowerRNG.NextDouble(value, value - 0.1));
-        }
+        // [Fact]
+        // public void NextDoubleCrossedBounds()
+        // {
+        //     double value = LowerValue;
+        //
+        //     // Allowed range: value
+        //     Assert.Equal(value, _lowerRNG.NextDouble(value, value));
+        //     // Allowed range: (value - 0.1, value]
+        //     Assert.Equal(value, _lowerRNG.NextDouble(value, value - 0.1));
+        // }
 
         [Fact]
         public void NextDoubleUpperBound()
         {
-            double value = UpperValue;
+            double value = ReturnedValue;
 
-            Assert.Equal(value, _upperRNG.NextDouble(value + 0.1));
-            Assert.Equal(value, _upperRNG.NextDouble(value, value + 0.1));
+            Assert.Equal(value, _boundedRNG.NextDouble(value + 0.1));
+            Assert.Equal(value, _boundedRNG.NextDouble(value, value + 0.1));
 
-            Assert.Throws<ArgumentException>(() => _upperRNG.NextDouble(value));
-            Assert.Throws<ArgumentException>(() => _upperRNG.NextDouble(value - 0.1, value));
+            Assert.Throws<ArgumentException>(() => _boundedRNG.NextDouble(value));
+            Assert.Throws<ArgumentException>(() => _boundedRNG.NextDouble(value - 0.1, value));
         }
         #endregion
 
         #region Template Tests
-
-        private void TestUnboundedIntFunction<T>(Func<T> unboundedGenFunc)
+        private static void TestUnboundedIntFunction<T>(Func<T> unboundedGenFunc)
         {
             T minValue = (T)typeof(T).GetField("MinValue")!.GetValue(null)!;
             T maxValue = (T)typeof(T).GetField("MaxValue")!.GetValue(null)!;
@@ -105,7 +92,7 @@ namespace ShaiRandom.UnitTests
             where T : IConvertible
         {
             // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
-            dynamic value = (T)Convert.ChangeType(LowerValue, typeof(T));
+            dynamic value = (T)Convert.ChangeType(ReturnedValue, typeof(T));
 
             Assert.Equal(value, upperBoundFunc(value + 1));
             Assert.Equal(value, dualBoundFunc(value, value + 1));
@@ -117,7 +104,7 @@ namespace ShaiRandom.UnitTests
             where T : IConvertible
         {
             // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
-            dynamic value = (T)Convert.ChangeType(UpperValue, typeof(T));
+            dynamic value = (T)Convert.ChangeType(ReturnedValue, typeof(T));
 
             // Allowed range: value
             Assert.Equal(value, generatorFunc(value, value));
@@ -131,7 +118,7 @@ namespace ShaiRandom.UnitTests
             where T : IConvertible
         {
             // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
-            dynamic value = (T)Convert.ChangeType(UpperValue, typeof(T));
+            dynamic value = (T)Convert.ChangeType(ReturnedValue, typeof(T));
 
             Assert.Equal(value, upperBoundFunc(value + 1));
             Assert.Equal(value, dualBoundFunc(value, value + 1));
@@ -141,19 +128,19 @@ namespace ShaiRandom.UnitTests
         }
         #endregion
 
-        #region Int
+        #region Test Int
 
         [Fact]
         public void NextIntUnbounded() => TestUnboundedIntFunction(_unboundedRNG.NextInt);
 
         [Fact]
-        public void NextIntLowerBound() => TestLowerBoundIntFunction<int>(_lowerRNG.NextInt, _lowerRNG.NextInt);
+        public void NextIntLowerBound() => TestLowerBoundIntFunction<int>(_boundedRNG.NextInt, _boundedRNG.NextInt);
 
         [Fact]
-        public void NextIntCrossedBounds() => TestCrossedBoundIntFunction<int>(_upperRNG.NextInt);
+        public void NextIntCrossedBounds() => TestCrossedBoundIntFunction<int>(_boundedRNG.NextInt);
 
         [Fact]
-        public void NextIntUpperBound() => TestUpperBoundIntFunction<int>(_upperRNG.NextInt, _upperRNG.NextInt);
+        public void NextIntUpperBound() => TestUpperBoundIntFunction<int>(_boundedRNG.NextInt, _boundedRNG.NextInt);
 
         #endregion
 

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -36,13 +36,110 @@ namespace ShaiRandom.UnitTests
 
         #region Template Tests
 
+        private (Func<T> unbounded, Func<T, T> outerBound, Func<T, T, T> dualBound) GetGenerationFunctions<T>(string name)
+            where T : notnull
+        {
+            // Find info for the functions
+            var unboundedInfo = typeof(KnownSeriesRandom).GetMethod(name, Array.Empty<Type>())
+                            ?? throw new Exception("Couldn't find unbounded generation method with the name given.");
+            var outerBoundInfo = typeof(KnownSeriesRandom).GetMethod(name, new []{typeof(T)})
+                             ?? throw new Exception("Couldn't generation method with the name given that takes a single (outer) bound.");
+            var dualBoundInfo = typeof(KnownSeriesRandom).GetMethod(name, new []{typeof(T), typeof(T)})
+                            ?? throw new Exception("Couldn't find generation method with the name given which takes both an inner and outer bound.");
+
+            // Create convenient Func wrappers from which we can call them.
+            T Unbounded()
+            {
+                try
+                {
+                    return (T)unboundedInfo.Invoke(_unboundedRNG, null)!;
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException!;
+                }
+
+            }
+
+            T OuterBound(T outer)
+            {
+                try
+                {
+                    return (T)outerBoundInfo.Invoke(_boundedRNG, new object[] { outer })!;
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException!;
+                }
+            }
+
+            T DualBound(T inner, T outer)
+            {
+                try
+                {
+                    return (T)dualBoundInfo.Invoke(_boundedRNG, new object[] { inner, outer })!;
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException!;
+                }
+            }
+
+            // Return functions
+            return (Unbounded, OuterBound, DualBound);
+        }
+
         private void TestIntFunctionBounds<T>(string nameOfFunctionToTest)
             where T : IConvertible
         {
             // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
             dynamic value = (T)Convert.ChangeType(ReturnedValue, typeof(T));
 
-            // Find the functions we're testing in the appropriate generators (via reflection)
+            // Get proxies to call the functions we are testing
+            var (unbounded, outerBound, dualBound) = GetGenerationFunctions<T>(nameOfFunctionToTest);
+
+            // Find min/max for unbounded functions, which should be the min/max values for the type itself
+            T minValue = (T)typeof(T).GetField("MinValue")!.GetValue(null)!;
+            T maxValue = (T)typeof(T).GetField("MaxValue")!.GetValue(null)!;
+
+            // Check that unbounded generation function allows anything in type's range
+            Assert.Equal(minValue, unbounded());
+            Assert.Equal(maxValue,unbounded());
+
+
+            // Check that bounded generation functions treat inner bounds as inclusive
+            Assert.Equal(value, outerBound(value + 1)); // TODO: Fix; currently duplicate of outerBound check below
+            Assert.Equal(value, dualBound(value, value + 1));
+
+            Assert.Throws<ArgumentException>(() => dualBound(value + 1, value + 2));
+
+            // Check that behavior is appropriate when the inner and outer bounds are crossed on bounded generation
+            // functions (ie. outer <= inner)
+            Assert.Equal(value, dualBound(value, value)); // Allowed range: value
+            Assert.Equal(value, dualBound(value, value - 1)); // Allowed range: value
+            Assert.Equal(value, dualBound(value, value - 2)); // Allowed range: [value - 1, value]
+
+            Assert.Throws<ArgumentException>(() => dualBound(value - 1, value - 2));
+            Assert.Throws<ArgumentException>(() => dualBound(value + 1, value));
+
+            // Check that bounded generation functions treat outer bounds as exclusive
+            Assert.Equal(value, outerBound(value + 1));
+            Assert.Equal(value, dualBound(value, value + 1));
+
+            Assert.Throws<ArgumentException>(() => outerBound(value));
+            Assert.Throws<ArgumentException>(() => dualBound(value - 1, value));
+        }
+
+        private void TestFloatingFunctionBounds<T>(string nameOfFunctionToTest, T maxValueLessThanOne)
+            where T : IConvertible
+        {
+            // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
+            dynamic value = (T)Convert.ChangeType(ReturnedValue, typeof(T));
+
+            // Get the correct 0-type for type T
+            T zero = (T)Convert.ChangeType(0.0, typeof(T));
+
+            // Find the functions we're testing (via reflection)
             var unbounded = typeof(KnownSeriesRandom).GetMethod(nameOfFunctionToTest, Array.Empty<Type>())
                             ?? throw new Exception("Couldn't find unbounded generation method with the name given.");
             var outerBound = typeof(KnownSeriesRandom).GetMethod(nameOfFunctionToTest, new []{typeof(T)})
@@ -50,36 +147,11 @@ namespace ShaiRandom.UnitTests
             var dualBound = typeof(KnownSeriesRandom).GetMethod(nameOfFunctionToTest, new []{typeof(T), typeof(T)})
                             ?? throw new Exception("Couldn't find generation method with the name given which takes both an inner and outer bound.");
 
-            // Find min/max for unbounded functions, which should be the min/max values for the type itself
-            T minValue = (T)typeof(T).GetField("MinValue")!.GetValue(null)!;
-            T maxValue = (T)typeof(T).GetField("MaxValue")!.GetValue(null)!;
+            // Check that the unbounded functions allow everything within range [0, 1)
+            Assert.Equal(zero, unbounded.Invoke(_unboundedRNG, null)!);
+            Assert.Equal(maxValueLessThanOne, unbounded.Invoke(_unboundedRNG, null)!);
 
-            // Check that unbounded generation function allows anything in type's range
-            Assert.Equal(minValue, (T)unbounded.Invoke(_unboundedRNG, null)!);
-            Assert.Equal(maxValue,(T)unbounded.Invoke(_unboundedRNG, null)!);
-
-
-            // Check that bounded generation functions treat inner bounds as inclusive
-            Assert.Equal(value, (T)outerBound.Invoke(_boundedRNG, new[] {value + 1})!); // TODO: Fix; currently duplicate of outerBound check below
-            Assert.Equal(value, (T)dualBound.Invoke(_boundedRNG, new[] {value, value + 1})!);
-
-            Assert.Throws<TargetInvocationException>(() => (T)dualBound.Invoke(_boundedRNG, new[] {value + 1, value + 2})!);
-
-            // Check that behavior is appropriate when the inner and outer bounds are crossed on bounded generation
-            // functions (ie. outer <= inner)
-            Assert.Equal(value, (T)dualBound.Invoke(_boundedRNG, new[] {value, value})!); // Allowed range: value
-            Assert.Equal(value, (T)dualBound.Invoke(_boundedRNG, new[] {value, value - 1})!); // Allowed range: value
-            Assert.Equal(value, (T)dualBound.Invoke(_boundedRNG, new[] {value, value - 2})!); // Allowed range: [value - 1, value]
-
-            Assert.Throws<TargetInvocationException>(() => (T)dualBound.Invoke(_boundedRNG, new[] {value - 1, value - 2})!);
-            Assert.Throws<TargetInvocationException>(() => (T)dualBound.Invoke(_boundedRNG, new[] {value + 1, value})!);
-
-            // Check that bounded generation functions treat outer bounds as exclusive
-            Assert.Equal(value, (T)outerBound.Invoke(_boundedRNG, new[] {value + 1})!);
-            Assert.Equal(value, (T)dualBound.Invoke(_boundedRNG, new[] {value, value + 1})!);
-
-            Assert.Throws<TargetInvocationException>(() => (T)outerBound.Invoke(_boundedRNG, new[] {value})!);
-            Assert.Throws<TargetInvocationException>(() => (T)dualBound.Invoke(_boundedRNG, new[] {value - 1, value})!);
+            // TODO: rest below UnboundedFloatingFunction
         }
 
         // TODO: Combine

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -151,7 +151,7 @@ namespace ShaiRandom.Generators
             if (value.CompareTo(minValue) < 0)
                 throw new ArgumentException("Value returned is less than minimum value.");
 
-            if (value.CompareTo(maxValue) >= 0)
+            if (maxValue.CompareTo(minValue) > 0 && value.CompareTo(maxValue) >= 0)
                 throw new ArgumentException("Value returned is greater than/equal to maximum value.");
 
             return value;
@@ -164,7 +164,7 @@ namespace ShaiRandom.Generators
             if (value.CompareTo(minValue) <= 0)
                 throw new ArgumentException("Value returned is less than/equal to minimum value.");
 
-            if (value.CompareTo(maxValue) >= 0)
+            if (maxValue.CompareTo(minValue) > 0 && value.CompareTo(maxValue) >= 0)
                 throw new ArgumentException("Value returned is greater than/equal to maximum value.");
 
             return value;
@@ -177,8 +177,8 @@ namespace ShaiRandom.Generators
             if (value.CompareTo(minValue) < 0)
                 throw new ArgumentException("Value returned is less than minimum value.");
 
-            if (value.CompareTo(maxValue) > 0)
-                throw new ArgumentException("Value returned is greater than/equal to maximum value.");
+            if (maxValue.CompareTo(minValue) >= 0 && value.CompareTo(maxValue) > 0)
+                throw new ArgumentException("Value returned is greater than maximum value.");
 
             return value;
         }

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -161,8 +161,13 @@ namespace ShaiRandom.Generators
             T value = ReturnValueFrom(series, ref seriesIndex);
             var (min, max) = GetMinAndMax(innerValue, outerValue);
 
-            if (min.CompareTo(max) == 0 && value.CompareTo(min) != 0)
-                throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+            if (min.CompareTo(max) == 0)
+            {
+                if (value.CompareTo(min) != 0)
+                    throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+
+                return value; // If bounds are the same, the bound is returned.
+            }
 
             if (value.CompareTo(min) <= 0)
                 throw new ArgumentException("Value returned is below the bounds of the generator function call.");


### PR DESCRIPTION
# Changes
- Fixed `KnownSeriesRandom`'s bound enforcement on its returned values to match the contract specified by `IEnhancedRandom`
- Added relatively comprehensive unit tests to ensure bounds are properly enforced by `KnownSeriesRandom`

# Goals/End State
The currently released version of `KnownSeriesRandom` has a few bugs which largely prevent its use with `ArchivalWrapper`, and some use cases in general.  Largely, the bugs pertain to the `KnownSeriesRandom`'s enforcement of the bounds of returned values (it's bounds check functions are off by one, or implementing min/max checks when they need to implement inner/outer).  Therefore, this PR does two things:

1. Adds a relatively comprehensive set of unit tests for `KnownSeriesRandom`'s generation functions, which check that it enforces the bounds of returned values properly (eg. that it returns anything valid according to the `IEnhancedRandom` contract, and throws exception if the next number in the sequence doesn't fit the constraint).
2. Fixes the `KnownSeriesRandom` bounds checks such that the unit tests pass.

Assuming the checks I'm running against the bounds are correct, this will not only correct the implementation of `KnownSeriesRandom`, but could also later form the basis for a generic set of unit tests which can check to ensure that an _arbitrary_ generator respects the bounds as defined by the `IEnhancedRandom` contract.  I didn't implement that in this PR, but it could be implemented something like this:

```CS
public void PerformRNG(IEnhancedRandom rng)
{
    for (int i = 0 ; i < 100; i++)
        rng.NextInt(0, 2);
        
    // More for loops testing different ranges/functions here
}

public void TestRNGBounds(IEnhancedRandom rng)
{
    var wrapper = new ArchivalWrapper(rng);
    PerformRNG(wrapper);
    
    // Extract KnownSeriesRandom that will generate same numbers as the generator created
    var ksr = wrapper.MakeArchivedSeries();
    
    // Since KnownSeriesRandom enforces bounds correctly, if it will allow the same operations as originally
   // performed to be performed on it, the original RNG must have generated valid values (although it doesn't
  // prove that it generated _all_ possible values, that's more work obviously and in some cases impractical)
  PerformRNG(ksr);
}
```

One thing that still needs cleanup, is `KnownSeriesRandom` uses incorrect parameter names for most of its functions; it tends to use `minValue` and `maxValue` instead of `innerBound` and `outerBound`.  I can fix this on the current PR, but figured it fell more into docs cleanup than anything else.