### PR TITLE
Optimized and Tested Serialization/Deserialization

### DIFF
--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -132,10 +132,8 @@ namespace ShaiRandom.UnitTests
 
             // Serialize generator; wrappers have a special-case starting sequence
             string ser = gen.StringSerialize();
-            if (gen.Tag.Length == 1)
-                Assert.StartsWith(gen.Tag, ser);
-            else
-                Assert.StartsWith("#" + gen.Tag, ser);
+            Assert.StartsWith(gen.Tag.Length == 1 ? $"{gen.Tag}" : $"#{gen.Tag}`", ser);
+            Assert.EndsWith("`", ser);
 
             // Deserialize generator
             var gen2 = AbstractRandom.Deserialize(ser);
@@ -161,7 +159,8 @@ namespace ShaiRandom.UnitTests
 
             // Serialize generator
             string ser = ksr.StringSerialize();
-            Assert.StartsWith("#" + ksr.Tag, ser);
+            Assert.StartsWith($"#{ksr.Tag}", ser);
+            Assert.EndsWith("`", ser);
 
             // Deserialize generator
             var ksr2 = (KnownSeriesRandom)AbstractRandom.Deserialize(ser);

--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -123,16 +123,19 @@ namespace ShaiRandom.UnitTests
 
         public static IEnumerable<IEnhancedRandom> Generators => _generators;
 
-            [Theory]
+        [Theory]
         [MemberDataEnumerable(nameof(Generators))]
         public void BasicSerDeserTest(IEnhancedRandom gen)
         {
             // Advance state, just to make sure we have a valid generator
             gen.NextULong();
 
-            // Serialize generator
+            // Serialize generator; wrappers have a special-case starting sequence
             string ser = gen.StringSerialize();
-            Assert.StartsWith(gen.Tag, ser);
+            if (gen.Tag.Length == 1)
+                Assert.StartsWith(gen.Tag, ser);
+            else
+                Assert.StartsWith("#" + gen.Tag, ser);
 
             // Deserialize generator
             var gen2 = AbstractRandom.Deserialize(ser);
@@ -158,7 +161,6 @@ namespace ShaiRandom.UnitTests
 
             // Serialize generator
             string ser = ksr.StringSerialize();
-            // TODO: Why is this special?
             Assert.StartsWith("#" + ksr.Tag, ser);
 
             // Deserialize generator

--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using ShaiRandom.Generators;
 using ShaiRandom.Wrappers;
 using Xunit;
+using XUnit.ValueTuples;
+
 namespace ShaiRandom.UnitTests
 {
     public class BasicTests
@@ -111,70 +114,66 @@ namespace ShaiRandom.UnitTests
 
     public class SerializationTests
     {
-        [Fact]
-        public void FourWheelSerDeserTest()
+        private static IEnhancedRandom[] _generators =
         {
-            FourWheelRandom random = new FourWheelRandom(123456789UL, 0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL);
-            random.NextULong();
-            string data = random.StringSerialize();
-            Assert.StartsWith("#FoWR`", data);
-            IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
-            Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(random.Matches(random2));
-        }
-        [Fact]
-        public void StrangerSerDeserTest()
+            new DistinctRandom(), new FourWheelRandom(), new LaserRandom(), new MizuchiRandom(),
+            new RomuTrioRandom(), new StrangerRandom(), new TricycleRandom(), new Xoshiro256StarStarRandom(),
+            new ArchivalWrapper(), new ReversingWrapper(), new TRGeneratorWrapper()
+        };
+
+        public static IEnumerable<IEnhancedRandom> Generators => _generators;
+
+            [Theory]
+        [MemberDataEnumerable(nameof(Generators))]
+        public void BasicSerDeserTest(IEnhancedRandom gen)
         {
-            StrangerRandom random = new StrangerRandom(0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL);
-            random.NextULong();
-            string data = random.StringSerialize();
-            Assert.StartsWith("#StrR`", data);
-            IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
-            Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(random.Matches(random2));
+            // Advance state, just to make sure we have a valid generator
+            gen.NextULong();
+
+            // Serialize generator
+            string ser = gen.StringSerialize();
+            Assert.StartsWith(gen.Tag, ser);
+
+            // Deserialize generator
+            var gen2 = AbstractRandom.Deserialize(ser);
+
+            // Check that its state is equivalent and it generates identical numbers
+            Assert.True(gen.Matches(gen2));
+            Assert.Equal(gen.NextULong(), gen2.NextULong());
         }
 
+        // Needs special serialization tests to ensure that not only its state is the same, but also the series
+        // themselves, which is not represented in the state.
         [Fact]
-        public void TRWrapperSerDeserTest()
+        public void KnownSeriesRandomSerDeserTest()
         {
-            TRGeneratorWrapper random = new TRGeneratorWrapper(new FourWheelRandom(123456789UL, 0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL));
-            random.NextULong();
-            string data = random.StringSerialize();
-            Assert.StartsWith("TFoWR`", data);
-            IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
-            Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(random.Matches(random2));
-        }
+            // Create a KSR with unique series per type
+            var ksr = new KnownSeriesRandom(
+                new[] { 1, 2 }, new[] { 2U, 3U }, new[] { 3.0, 4.0 },
+                new[] { true, false }, new[] { (byte)4, (byte)5 },
+                new[] { 5f, 6f }, new[] { 6L, 7L }, new[] { 7UL, 8UL });
 
-        [Fact]
-        public void ReversingWrapperSerDeserTest()
-        {
-            ReversingWrapper random = new ReversingWrapper(new FourWheelRandom(123456789UL, 0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL));
-            random.NextULong();
-            string data = random.StringSerialize();
-            Assert.StartsWith("RFoWR`", data);
-            IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
-            Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(random.Matches(random2));
+            // Advance all states (so the indices are not their starting value)
+            ksr.SetState(1);
 
-            random.Wrapped = new StrangerRandom(123456789UL, 0xFA7BAB1E5UL, 0xB0BAFE77UL, 0x1234123412341234UL);
-            random.NextULong();
-            data = random.StringSerialize();
-            Assert.StartsWith("RStrR`", data);
-            random2 = AbstractRandom.Deserialize(data);
-            Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(random.Matches(random2));
-        }
-        [Fact]
-        public void KnownSeriesSerDeserTest()
-        {
-            KnownSeriesRandom random = new KnownSeriesRandom(new [] { 1, 3, -7 }, new uint[] { 2, 8, 12}, new [] { -1.1, 2.0, 1e30}, null, null, null, null, new [] { 0xB0BAFE77BA77UL, 0xDEADBEEFUL, 0x1337CAFEBABEUL });
-            random.NextULong();
-            string data = random.StringSerialize();
-            Assert.StartsWith("#KnSR`", data);
-            IEnhancedRandom random2 = AbstractRandom.Deserialize(data);
-            Assert.Equal(random.NextULong(), random2.NextULong());
-            Assert.True(random.Matches(random2));
+            // Serialize generator
+            string ser = ksr.StringSerialize();
+            // TODO: Why is this special?
+            Assert.StartsWith("#" + ksr.Tag, ser);
+
+            // Deserialize generator
+            var ksr2 = (KnownSeriesRandom)AbstractRandom.Deserialize(ser);
+            // Check that its state (indices) are equivalent to the original
+            Assert.True(ksr.Matches(ksr2));
+            // Check that each list is identical
+            Assert.Equal(ksr.IntSeries, ksr2.IntSeries);
+            Assert.Equal(ksr.UIntSeries, ksr2.UIntSeries);
+            Assert.Equal(ksr.DoubleSeries, ksr2.DoubleSeries);
+            Assert.Equal(ksr.BoolSeries, ksr2.BoolSeries);
+            Assert.Equal(ksr.ByteSeries, ksr2.ByteSeries);
+            Assert.Equal(ksr.FloatSeries, ksr2.FloatSeries);
+            Assert.Equal(ksr.LongSeries, ksr2.LongSeries);
+            Assert.Equal(ksr.ULongSeries, ksr2.ULongSeries);
         }
     }
 }

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using ShaiRandom.Wrappers;
 
 namespace ShaiRandom.Generators
@@ -74,7 +75,22 @@ namespace ShaiRandom.Generators
         }
 
         /// <inheritdoc />
-        public abstract string StringSerialize();
+        public virtual string StringSerialize()
+        {
+            var ser = new StringBuilder("#");
+            ser.Append(Tag);
+            ser.Append('`');
+            for (int i = 0; i < StateCount - 1; i++)
+            {
+                ser.Append($"{SelectState(i):X}");
+                ser.Append('~');
+            }
+
+            ser.Append($"{SelectState(StateCount - 1):X}");
+            ser.Append('`');
+
+            return ser.ToString();
+        }
 
         /// <inheritdoc />
         public virtual IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using ShaiRandom.Wrappers;
 
 namespace ShaiRandom.Generators
@@ -76,7 +77,17 @@ namespace ShaiRandom.Generators
         public abstract string StringSerialize();
 
         /// <inheritdoc />
-        public abstract IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data);
+        public virtual IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
+        {
+            int idx = data.IndexOf('`');
+
+            for (int i = 0; i < StateCount - 1; i++)
+                SetSelectedState(i, ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), NumberStyles.HexNumber));
+
+            SetSelectedState(StateCount - 1, ulong.Parse(data.Slice(idx + 1, -1 - idx + data.IndexOf('`', idx + 1)), NumberStyles.HexNumber));
+
+            return this;
+        }
 
         /// <summary>
         /// Given data from a string produced by <see cref="StringSerialize()"/> on any valid subclass of AbstractRandom,

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -159,8 +159,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new DistinctRandom(State);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#DisR`{State:X}`";
     }
 }

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -163,10 +164,10 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#DisR`{State:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            State = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            State = ulong.Parse(data.Slice(idx + 1, -1 - idx + data[(idx + 1)..].IndexOf('`')), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 1 state that only returns each ulong result exactly once over its period.

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -162,13 +162,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#DisR`{State:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            State = ulong.Parse(data.Slice(idx + 1, -1 - idx + data[(idx + 1)..].IndexOf('`')), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -249,13 +250,13 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#FoWR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateD = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -248,16 +248,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#FoWR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateD = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -245,8 +245,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new FourWheelRandom(StateA, StateB, StateC, StateD);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#FoWR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
     }
 }

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 4 states, built around a "chaotic" construction with no guarantee of a minimum period, but likely to be a very long one.

--- a/ShaiRandom/Generators/IEnhancedRandom.cs
+++ b/ShaiRandom/Generators/IEnhancedRandom.cs
@@ -69,13 +69,13 @@ namespace ShaiRandom.Generators
         string StringSerialize();
 
         /// <summary>
-        /// Given a string produced by <see cref="StringSerialize"/>, if the specified type is compatible,
+        /// Given data from a string produced by <see cref="StringSerialize"/>, if the specified type is compatible,
         /// then this method sets the state of this IEnhancedRandom to the specified stored state.
         /// This is an optional operation for classes that only implement IEnhancedRandom; AbstractRandom requires an implementation.
         /// </summary>
-        /// <param name="data">A string produced by StringSerialize.</param>
+        /// <param name="data">Data from a string produced by StringSerialize.</param>
         /// <returns>This IEnhancedRandom, after modifications.</returns>
-        IEnhancedRandom StringDeserialize(string data);
+        IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data);
 
         /// <summary>
         /// Gets a selected state value from this AbstractRandom, by index.

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -20,20 +20,59 @@ namespace ShaiRandom.Generators
     {
         private int _boolIndex;
         internal readonly List<bool> _boolSeries;
+        /// <summary>
+        /// Series of booleans returned by this generator.
+        /// </summary>
+        public IReadOnlyList<bool> BoolSeries => _boolSeries;
+
         private int _byteIndex;
         internal readonly List<byte> _byteSeries;
+        /// <summary>
+        /// Series of bytes returned by this generator.
+        /// </summary>
+        public IReadOnlyList<byte> ByteSeries => _byteSeries;
+
         private int _doubleIndex;
         internal readonly List<double> _doubleSeries;
+        /// <summary>
+        /// Series of doubles returned by this generator.
+        /// </summary>
+        public IReadOnlyList<double> DoubleSeries => _doubleSeries;
+
         private int _floatIndex;
         internal readonly List<float> _floatSeries;
+        /// <summary>
+        /// Series of floats returned by this generator.
+        /// </summary>
+        public IReadOnlyList<float> FloatSeries => _floatSeries;
+
         private int _intIndex;
         internal readonly List<int> _intSeries;
+        /// <summary>
+        /// Series of integers returned by this generator.
+        /// </summary>
+        public IReadOnlyList<int> IntSeries => _intSeries;
+
         private int _uintIndex;
         internal readonly List<uint> _uintSeries;
+        /// <summary>
+        /// Series of uints returned by this generator.
+        /// </summary>
+        public IReadOnlyList<uint> UIntSeries => _uintSeries;
+
         private int _longIndex;
         internal readonly List<long> _longSeries;
+        /// <summary>
+        /// Series of longs returned by this generator.
+        /// </summary>
+        public IReadOnlyList<long> LongSeries => _longSeries;
+
         private int _ulongIndex;
         internal readonly List<ulong> _ulongSeries;
+        /// <summary>
+        /// Series of ulong values returned by this generator.
+        /// </summary>
+        public IReadOnlyList<ulong> ULongSeries => _ulongSeries;
 
         /// <summary>
         /// Creates a KnownSeriesRandom that is a copy of the given one.

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -681,58 +681,58 @@ namespace ShaiRandom.Generators
             int idx = data.IndexOf('`');
 
             // Int
-            _intIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _intIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _intSeries.Clear();
-            var seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            var seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _intSeries.Add(int.Parse(numData));
 
             // UInt
-            _uintIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _uintIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _uintSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _uintSeries.Add(uint.Parse(numData));
 
             // Double
-            _doubleIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _doubleIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _doubleSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _doubleSeries.Add(double.Parse(numData));
 
             // Bool
-            _boolIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _boolIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _boolSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _boolSeries.Add(bool.Parse(numData));
 
             // Byte
-            _byteIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _byteIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _byteSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _byteSeries.Add(byte.Parse(numData));
 
             // Float
-            _floatIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _floatIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _floatSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _floatSeries.Add(float.Parse(numData));
 
             // Long
-            _longIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _longIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _longSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
             foreach (var numData in seriesData.Tokenize('|'))
                 _longSeries.Add(long.Parse(numData));
 
             // ULong
-            _ulongIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _ulongIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _ulongSeries.Clear();
-            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            seriesData = data.Slice(idx + 1, -1 - idx + data.IndexOf('`', idx + 1));
             foreach (var numData in seriesData.Tokenize('|'))
                 _ulongSeries.Add(ulong.Parse(numData));
             return this;

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using Microsoft.Toolkit.HighPerformance;
 
 namespace ShaiRandom.Generators
 {
@@ -635,49 +637,101 @@ namespace ShaiRandom.Generators
         public ulong Skip(ulong distance) => throw new NotSupportedException();
 
         /// <inheritdoc />
-        public IEnhancedRandom StringDeserialize(string data)
+        public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            _intIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _intSeries.Clear(); _intSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToInt32(s)).ToList());
-            _uintIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _uintSeries.Clear(); _uintSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToUInt32(s)).ToList());
-            _doubleIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _doubleSeries.Clear(); _doubleSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToDouble(s)).ToList());
-            _boolIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _boolSeries.Clear(); _boolSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToBoolean(s)).ToList());
-            _byteIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _byteSeries.Clear(); _byteSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToByte(s)).ToList());
-            _floatIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _floatSeries.Clear(); _floatSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToSingle(s)).ToList());
-            _longIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _longSeries.Clear(); _longSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToInt64(s)).ToList());
-            _ulongIndex = Convert.ToInt32(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
-            _ulongSeries.Clear(); _ulongSeries.AddRange(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('`', idx + 1))).Split('|', StringSplitOptions.RemoveEmptyEntries).Select(s => Convert.ToUInt64(s)).ToList());
+
+            // Int
+            _intIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _intSeries.Clear();
+            var seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _intSeries.Add(int.Parse(numData));
+
+            // UInt
+            _uintIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _uintSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _uintSeries.Add(uint.Parse(numData));
+
+            // Double
+            _doubleIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _doubleSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _doubleSeries.Add(double.Parse(numData));
+
+            // Bool
+            _boolIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _boolSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _boolSeries.Add(bool.Parse(numData));
+
+            // Byte
+            _byteIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _byteSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _byteSeries.Add(byte.Parse(numData));
+
+            // Float
+            _floatIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _floatSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _floatSeries.Add(float.Parse(numData));
+
+            // Long
+            _longIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _longSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _longSeries.Add(long.Parse(numData));
+
+            // ULong
+            _ulongIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))));
+            _ulongSeries.Clear();
+            seriesData = data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~')));
+            foreach (var numData in seriesData.Tokenize('|'))
+                _ulongSeries.Add(ulong.Parse(numData));
             return this;
 
+        }
+
+        private void SerializeList<T>(StringBuilder ser, IReadOnlyList<T> series, char lastChar = '~')
+        {
+            foreach (var item in series)
+            {
+                ser.Append(item); ser.Append('|');
+            }
+            ser.Remove(ser.Length - 1, 1);
+            ser.Append(lastChar);
         }
 
         /// <inheritdoc />
         public string StringSerialize()
         {
-            string ser = "#KnSR`";
-            ser += _intIndex + "~";
-            ser = _intSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _uintIndex + "~";
-            ser = _uintSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _doubleIndex + "~";
-            ser = _doubleSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _boolIndex + "~";
-            ser = _boolSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _byteIndex + "~";
-            ser = _byteSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _floatIndex + "~";
-            ser = _floatSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _longIndex + "~";
-            ser = _longSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "~";
-            ser += _ulongIndex + "~";
-            return _ulongSeries.Aggregate(ser, (s, n) => s + n + "|").TrimEnd('|') + "`";
+            StringBuilder ser = new StringBuilder("#KnSR`");
+            ser.Append(_intIndex); ser.Append('~');
+            SerializeList(ser, _intSeries);
+            ser.Append(_uintIndex); ser.Append('~');
+            SerializeList(ser, _uintSeries);
+            ser.Append(_doubleIndex); ser.Append('~');
+            SerializeList(ser, _doubleSeries);
+            ser.Append(_boolIndex); ser.Append('~');
+            SerializeList(ser, _boolSeries);
+            ser.Append(_byteIndex); ser.Append('~');
+            SerializeList(ser, _byteSeries);
+            ser.Append(_floatIndex); ser.Append('~');
+            SerializeList(ser, _floatSeries);
+            ser.Append(_longIndex); ser.Append('~');
+            SerializeList(ser, _longSeries);
+            ser.Append(_ulongIndex); ser.Append('~');
+            SerializeList(ser, _ulongSeries, '`');
+
+            return ser.ToString();
         }
     }
 }

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -211,7 +211,5 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new LaserRandom(StateA, StateB);
 
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#LasR`{StateA:X}~{StateB:X}`";
     }
 }

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 2 states, more here later. This one supports <see cref="Skip(ulong)"/>.

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -213,14 +213,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#LasR`{StateA:X}~{StateB:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -214,11 +215,11 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#LasR`{StateA:X}~{StateB:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 2 states, more here later.

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -206,14 +206,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#MizR`{StateA:X}~{StateB:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -203,8 +203,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new MizuchiRandom(StateA, StateB);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#MizR`{StateA:X}~{StateB:X}`";
     }
 }

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -207,11 +208,11 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#MizR`{StateA:X}~{StateB:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -237,8 +237,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new RomuTrioRandom(StateA, StateB, StateC);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#RTrR`{StateA:X}~{StateB:X}~{StateC:X}`";
     }
 }

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -18,6 +18,7 @@
 // implementation of https://romu-random.org/ .
 
 using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -241,12 +242,12 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#RTrR`{StateA:X}~{StateB:X}~{StateC:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -240,15 +240,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#RTrR`{StateA:X}~{StateB:X}~{StateC:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -17,9 +17,6 @@
 // Derived from https://github.com/bgrainger/RomuRandom , which is an
 // implementation of https://romu-random.org/ .
 
-using System;
-using System.Globalization;
-
 namespace ShaiRandom.Generators
 {
     /// <summary>

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 4 states, more here later. This one has a good guaranteed minimum period, (2 to the 65) - 2.

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -291,13 +292,13 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#StrR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateD = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -290,16 +290,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#StrR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateD = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -287,8 +287,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new StrangerRandom(StateA, StateB, StateC, StateD);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#StrR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
     }
 }

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -218,15 +218,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#TriR`{StateA:X}~{StateB:X}~{StateC:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 3 states, more here later.

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -219,12 +220,12 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#TriR`{StateA:X}~{StateB:X}~{StateC:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -215,8 +215,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new TricycleRandom(StateA, StateB, StateC);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#TriR`{StateA:X}~{StateB:X}~{StateC:X}`";
     }
 }

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace ShaiRandom.Generators
 {
@@ -248,13 +249,13 @@ namespace ShaiRandom.Generators
         public override string StringSerialize() => $"#XSSR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             int idx = data.IndexOf('`');
-            StateA = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateB = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateC = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))), 16);
-            StateD = Convert.ToUInt64(data.Substring(idx + 1, -1 - idx + (      data.IndexOf('`', idx + 1))), 16);
+            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
+            StateD = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
             return this;
         }
     }

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -247,16 +247,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override string StringSerialize() => $"#XSSR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
-
-        /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            StateA = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateB = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateC = ulong.Parse(data.Slice(idx + 1, -1 - idx + (idx = data[(idx + 1)..].IndexOf('~'))), NumberStyles.HexNumber);
-            StateD = ulong.Parse(data.Slice(idx + 1, -1 - idx + (      data[(idx + 1)..].IndexOf('`'))), NumberStyles.HexNumber);
-            return this;
-        }
     }
 }

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Globalization;
-
-namespace ShaiRandom.Generators
+﻿namespace ShaiRandom.Generators
 {
     /// <summary>
     /// It's an AbstractRandom with 4 states, implementing a known-rather-good algorithm that is 4-dimensionally equidistributed.

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -244,8 +244,5 @@ namespace ShaiRandom.Generators
 
         /// <inheritdoc />
         public override IEnhancedRandom Copy() => new Xoshiro256StarStarRandom(StateA, StateB, StateC, StateD);
-
-        /// <inheritdoc />
-        public override string StringSerialize() => $"#XSSR`{StateA:X}~{StateB:X}~{StateC:X}~{StateD:X}`";
     }
 }

--- a/ShaiRandom/ShaiRandom.csproj
+++ b/ShaiRandom/ShaiRandom.csproj
@@ -100,6 +100,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageReference Include="Troschuetz.Random" Version="5.0.1" />
   </ItemGroup>
 

--- a/ShaiRandom/SpanHelpers.cs
+++ b/ShaiRandom/SpanHelpers.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace ShaiRandom
+{
+    /// <summary>
+    /// Some helper methods that can be useful when parsing span data.
+    /// </summary>
+    public static class SpanHelpers
+    {
+        /// <summary>
+        /// IndexOf function which takes a starting point (like the similar overload for string).
+        /// </summary>
+        /// <param name="span"/>
+        /// <param name="value">Value to search for.</param>
+        /// <param name="start">Index at which to start searching.</param>
+        /// <typeparam name="T">Type of elements in the span.</typeparam>
+        /// <returns>
+        /// Returns the index of first occurence of <paramref name="value"/> in <paramref name="span"/> which occurs on
+        /// or after <paramref name="start"/>; or -1 if no such occurence exists.
+        /// </returns>
+        public static int IndexOf<T>(this ReadOnlySpan<T> span, T value, int start)
+            where T : IEquatable<T>
+        {
+            for (int i = start + 1; i < span.Length; i++)
+                if (span[i].Equals(value))
+                    return i;
+
+            return -1;
+        }
+    }
+}

--- a/ShaiRandom/Wrappers/ArchivalWrapper.cs
+++ b/ShaiRandom/Wrappers/ArchivalWrapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using ShaiRandom.Generators;
 
 namespace ShaiRandom.Wrappers
@@ -472,15 +473,22 @@ namespace ShaiRandom.Wrappers
         }
 
         /// <inheritdoc />
-        public string StringSerialize() => "A" + Wrapped.StringSerialize().Substring(1) + MakeArchivedSeries().StringSerialize();
+        public string StringSerialize()
+        {
+            var ser = new StringBuilder("A");
+            ser.Append(Wrapped.StringSerialize().AsSpan(1));
+            ser.Append(MakeArchivedSeries().StringSerialize());
+
+            return ser.ToString();
+        }
 
         /// <inheritdoc />
-        public IEnhancedRandom StringDeserialize(string data)
+        public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
-            int breakPoint = data.IndexOf('`', 6) + 1;
-            Wrapped.StringDeserialize(data.Substring(0, breakPoint));
+            int breakPoint = data[6..].IndexOf('`') + 1;
+            Wrapped.StringDeserialize(data[..breakPoint]);
             KnownSeriesRandom ksr = new KnownSeriesRandom();
-            ksr.StringDeserialize(data.Substring(breakPoint));
+            ksr.StringDeserialize(data[breakPoint..]);
             _boolSeries.Clear();
             _byteSeries.Clear();
             _doubleSeries.Clear();

--- a/ShaiRandom/Wrappers/ArchivalWrapper.cs
+++ b/ShaiRandom/Wrappers/ArchivalWrapper.cs
@@ -475,7 +475,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public string StringSerialize()
         {
-            var ser = new StringBuilder("A");
+            var ser = new StringBuilder(Tag);
             ser.Append(Wrapped.StringSerialize().AsSpan(1));
             ser.Append(MakeArchivedSeries().StringSerialize());
 

--- a/ShaiRandom/Wrappers/ArchivalWrapper.cs
+++ b/ShaiRandom/Wrappers/ArchivalWrapper.cs
@@ -485,7 +485,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
-            int breakPoint = data[6..].IndexOf('`') + 1;
+            int breakPoint = data.IndexOf('`', 6) + 1;
             Wrapped.StringDeserialize(data[..breakPoint]);
             KnownSeriesRandom ksr = new KnownSeriesRandom();
             ksr.StringDeserialize(data[breakPoint..]);

--- a/ShaiRandom/Wrappers/ArchivalWrapper.cs
+++ b/ShaiRandom/Wrappers/ArchivalWrapper.cs
@@ -102,7 +102,7 @@ namespace ShaiRandom.Wrappers
 
         /// <summary>
         /// This generator has the same number of states as the wrapped generator; the recorded values are not considered state.
-        /// They can be considered state for the <see cref="Series"/> this contains.
+        /// They can be considered state for the <see cref="KnownSeriesRandom"/> this creates.
         /// </summary>
         public int StateCount => Wrapped.StateCount;
 

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -92,7 +92,7 @@ namespace ShaiRandom.Wrappers
         public override string StringSerialize() => "R" + Wrapped.StringSerialize().Substring(1);
 
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             Wrapped.StringDeserialize(data);
             return this;

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using ShaiRandom.Generators;
 
 namespace ShaiRandom.Wrappers
@@ -89,7 +90,13 @@ namespace ShaiRandom.Wrappers
         public override void Seed(ulong seed) => Wrapped.Seed(seed);
 
         /// <inheritdoc />
-        public override string StringSerialize() => "R" + Wrapped.StringSerialize().Substring(1);
+        public override string StringSerialize()
+        {
+            var ser = new StringBuilder(Tag);
+            ser.Append(Wrapped.StringSerialize().AsSpan(1));
+
+            return ser.ToString();
+        }
 
         /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -1,4 +1,5 @@
-﻿using ShaiRandom.Generators;
+﻿using System;
+using ShaiRandom.Generators;
 using Troschuetz.Random;
 
 namespace ShaiRandom.Wrappers
@@ -79,7 +80,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public override string StringSerialize() => "T"+ Wrapped.StringSerialize().Substring(1);
         /// <inheritdoc />
-        public override IEnhancedRandom StringDeserialize(string data)
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
             Wrapped.StringDeserialize(data);
             return this;

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using ShaiRandom.Generators;
 using Troschuetz.Random;
 
@@ -78,7 +79,13 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public override ulong PreviousULong() => Wrapped.PreviousULong();
         /// <inheritdoc />
-        public override string StringSerialize() => "T"+ Wrapped.StringSerialize().Substring(1);
+        public override string StringSerialize()
+        {
+            var ser = new StringBuilder(Tag);
+            ser.Append(Wrapped.StringSerialize().AsSpan(1));
+
+            return ser.ToString();
+        }
         /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {


### PR DESCRIPTION
# Changes
- Modified `IEnhancedRandom.StringDeserialize` API to take `ReadOnlySpan<char>` as its data type instead of `string`
    - Strings are implicitly convertible to `ReadOnlySpan<char>`, so it won't affect user code much
    - Applied to `AbstractRandom.Deserialize` as well
- Moved basic serialization/deserialization logic from the generators to the `AbstractRandom` type
    - Default implementation assumes generator supports `SelectState` and `SetSelectedState`, however is overridable
    - Note: This change should NOT modify the serialization format
- Utilized `StringBuilder` in serialization logic, instead of string concatenation
- Added dependency on the `Microsoft.Toolkit.HighPerformance` NuGet package.
    - Used in deserialization parsing for `KnownSeriesRandom`; may have other applications as well
- Added properties in `KnownSeriesRandom` that expose the underlying series in a read-only fashion (users still can't modify the values in them)
- Revamped serialization/deserialization unit tests to use generic code that will work for all typical generators
    - Uses XUnit Theories to avoid code duplication
    - This also adds serialization tests to all of the current generator types implemented

# Goals/End-state
The current implementation of `StringDeserialize` performs quite a few calls to `string.Substring()`.  Since strings are immutable in C#, each call typically results in a copy of the substring being allocated.  Although the string allocations likely don't represent a serious bottleneck since serialization/deserialization doesn't happen frequently in most cases, the allocations also aren't needed, since C# has spans.  Furthermore, since the strings representing `KnownSeriesRandom` series could get rather large, it may be a concern here.

Therefore, I've modified the API for `StringDeserialize` and `AbstractRandom.Deserialize` to take a `ReadOnlySpan<char>` instead of a `string` as its parameter.  Strings are implicitly convertible to `ReadOnlySpan<char>` in modern .NET, so this shouldn't really affect the usage from a user's perspective.  Primarily, the benefit of this is that `ReadOnlySpan<char>` is a stack-allocated struct, which is effectively just a pointer to data and a length; so we can do substring-like operations without allocating a copy of any of the string's data.

The interface for spans does have some benefits in terms of convenient syntax, however unfortunately the built-in parsing-related APIs for them are a bit more limited in some senses, when compared to what is available for `string`.  Primarily, there were two areas of concern to deal with during this port.

First, the `Convert.ToX` functions do not have overloads that take `ReadOnlySpan<char>`; only `string`.  This is particularly frustrating since the current implementation of these functions actually calls a private function which takes `ReadOnlySpan<char>`; the API is simply not publicly exposed.  Nevertheless, the `XType.Parse` methods do have an overload that takes `ReadOnlySpan`, and although that API is a bit more limited in functionality, it is sufficient for this use case; so I switched the parsing to use that one instead.

Second, there is no equivalent of `string.Split` for spans.  Given that you can't use a span type as a type argument (so `IEnumerable<ReadOnlySpan<char>>` is not a legal type), this makes sense; and in fact the `string.Split` method itself performs a large amount of allocation (allocates an array and strings), so it wouldn't make sense to have an equivalent for spans.  Nevertheless, the `string.Split` function is used in the `KnownSeriesRandom.StringDeserialize` method; so in order to port to spans, an equivalent of some sort is needed.  One option is to simply allocate a string and use `Split`; but this would have mitigated the benefit of spans for this use case.  Another option is to write some sort of splitting or tokenizing logic manually; but this can be cumbersome and somewhat intensive on code duplication, due to the limitations of spans not being able to be used as the type argument for `IEnumerable`.

Therefore, I elected to add a dependency on the [Microsoft.Toolkit.HighPerformance](https://www.nuget.org/packages/Microsoft.Toolkit.HighPerformance/) library. It is part of the [Community Toolkit](https://github.com/CommunityToolkit/dotnet), which implements a huge selection of packages/helper function for a wide variety of purposes.  This package in particular should support all frameworks that ShaiRandom does and more (it supports even frameworks prior to .NET Standard 2.1).  Of particular interest to the current PR is that it provides a [Tokenize function](https://github.com/CommunityToolkit/dotnet/blob/c5ab771da4eb43e31ce79767badd9d9f7d7342c1/CommunityToolkit.HighPerformance/Extensions/ReadOnlySpanExtensions.cs#L325) for `ReadOnlySpan`, which allows efficient parsing of spans with a convenient syntax.  This function is used in this PR's implementation of `KnownSeriesRandom.StringDeserialize`.

This package may also have some applications elsewhere in the library; it provides an array of [bit operations](https://github.com/CommunityToolkit/dotnet/blob/main/CommunityToolkit.HighPerformance/Helpers/BitHelper.cs) which have been optimized extensively, as well as some other data structures.

I have also changed the serialization logic to use `StringBuilder` instead of string concatenation; again because since `StringBuilder` is mutable, it should be more efficient than concatenation for many of these cases.

Another change is that, for most generators in the library, they now rely on implementations of `StringSerialize` and `StringDeserialize` that exist in `AbstractRandom`.  The serialization format used currently appears to be fairly well-defined; the only variable was the number of states that were serialized or deserialized.  Since the `IEnhancedRandom` interface provides the `StateCount`, `SelectState`, and `SetSelectedState` functions, it is possible to implement the serialization format without knowing the specifics of the generator.  Any generators that do not support these functions, or any generators that use a different format (eg. wrappers or `KnownSeriesRandom`, have to implement the functions in a custom way still, which the `AbstractRandom` interface still allows. Note that this SHOULD NOT change the format of the actual strings generated itself in any way; if it does, please feel free to consider it a bug.

Finally, I refactored the serialization unit tests.  As implemented on the `main` branch, they are extremely repetitive and somewhat difficult to maintain as a result.  Therefore, I used XUnit's `[Theory]` to create a single generic test which can test any typical `IEnhancedRandom` which supports both read and write access.  `KnownSeriesRandom` has its own test; but all the others simply use the generic one.  During the process, I also ensured that all currently implemented generators are tested for proper serialization/deserialization mechanics.

Finally, in order to properly unit test `KnownSeriesRandom`, I had to add public fields which expose the underlying series for `KnownSeriesRandom` (in a read-only fashion).  This way, its specific unit test for serialization/deserialization can check to ensure that the series themselves are the same, as well as the indices.