### PR TITLE
Added Bounds Tests

### DIFF
--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using ShaiRandom.Generators;
-using ShaiRandom.Wrappers;
 using Xunit;
 using XUnit.ValueTuples;
 

--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using ShaiRandom.Generators;
 using ShaiRandom.Wrappers;
 using Xunit;
@@ -114,14 +115,8 @@ namespace ShaiRandom.UnitTests
 
     public class SerializationTests
     {
-        private static IEnhancedRandom[] _generators =
-        {
-            new DistinctRandom(), new FourWheelRandom(), new LaserRandom(), new MizuchiRandom(),
-            new RomuTrioRandom(), new StrangerRandom(), new TricycleRandom(), new Xoshiro256StarStarRandom(),
-            new ArchivalWrapper(), new ReversingWrapper(), new TRGeneratorWrapper()
-        };
-
-        public static IEnumerable<IEnhancedRandom> Generators => _generators;
+        private static readonly IEnhancedRandom[] s_generators = DataGenerators.CreateGenerators(true).ToArray();
+        public static IEnumerable<IEnhancedRandom> Generators => s_generators;
 
         [Theory]
         [MemberDataEnumerable(nameof(Generators))]

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -124,6 +124,16 @@ namespace ShaiRandom.UnitTests
         [MemberDataTuple(nameof(SignedTestData))]
         void NextLong(int inner, int outer, IEnhancedRandom rng)
             => TestIntegerFunc<long>(rng, "NextLong", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(UnsignedTestData))]
+        void NextUInt(int inner, int outer, IEnhancedRandom rng)
+            => TestIntegerFunc<uint>(rng, "NextUInt", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(SignedTestData))]
+        void NextInt(int inner, int outer, IEnhancedRandom rng)
+            => TestIntegerFunc<int>(rng, "NextInt", (inner, outer));
         #endregion
     }
 }

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -19,11 +19,22 @@ namespace ShaiRandom.UnitTests
         private static readonly (int inner, int outer)[] s_signedBounds = { (1, 3), (2, 2), (-3, -1), (-2, 1), (1, -2) };
         private static readonly (int inner, int outer)[] s_unsignedBounds = { (1, 3), (2, 2), (3, 1) };
 
+        // MUST be different than values used in other sets.
+        private const float EqualTestValue = 1.2f;
+        private static readonly (float inner, float outer)[] s_floatingBounds =
+        {
+            (0.000000001f, 0.000000003f), (EqualTestValue, EqualTestValue), (-0.000000003f, -0.000000001f),
+            (-0.000000001f, 0.000000001f), (0.000000001f, -0.000000001f)
+        };
+
         public static IEnumerable<(int inner, int outer, IEnhancedRandom rng)> SignedTestData =
             s_signedBounds.Combinate(s_generators);
 
         public static IEnumerable<(int inner, int outer, IEnhancedRandom rng)> UnsignedTestData =
             s_unsignedBounds.Combinate(s_generators);
+
+        public static IEnumerable<(float inner, float outer, IEnhancedRandom rng)> FloatingTestData =
+            s_floatingBounds.Combinate(s_generators);
 
         #region Template Tests
         private (Func<T, T> outerBound, Func<T, T, T> dualBound) GetGenerationFunctions<T>(IEnhancedRandom rng, string name)
@@ -64,7 +75,7 @@ namespace ShaiRandom.UnitTests
             return (OuterBound, DualBound);
         }
 
-        private void TestIntegerFunc<T>(IEnhancedRandom rng, string funcName, (int inner, int outer) bounds)
+        private void TestIntFunctionBounds<T>(IEnhancedRandom rng, string funcName, (int inner, int outer) bounds)
             where T : IComparable<T>
         {
             // Create dynamic variable for outer so we can add/subtract when checking the bound extents
@@ -111,6 +122,77 @@ namespace ShaiRandom.UnitTests
             Assert.True(frequencyOuter.ContainsKey((T)Convert.ChangeType(0, typeof(T))));
             Assert.True(frequencyDual.ContainsKey(outerInclusive));
         }
+
+        // NOTE: This function works for the regular floating-point functions, as well as both the inclusive and exclusive
+        // bound functions (at least for now).  We can't really do any sanity checking to ensure the bounds are precise;
+        // we can only check to ensure there is more than 1 unique value if the range values weren't equal, and also
+        // that all values returned were at least within the bounds; and all that applies to our test data regardless
+        // of the exclusivity or inclusivity of its bounds.
+        private void TestFloatingFunctionBounds<T>(IEnhancedRandom rng, string funcName, (float inner, float outer) bounds)
+            where T : IComparable<T>
+        {
+            // Create dynamic variable for outer so we can add/subtract when checking the bound extents
+            dynamic inner = (T)Convert.ChangeType(bounds.inner, typeof(T));
+            dynamic outer = (T)Convert.ChangeType(bounds.outer, typeof(T));
+
+            // Check if we're explicitly comparing for equality, so we can avoid our sanity check for more than
+            // one unique returned value in that case
+            bool isEqualCase =  Math.Abs(bounds.inner - 1.2f) < 0.00000000001;
+
+            // Sanity check to make sure we haven't made the test case data so precise that floating-point imprecision
+            // bit us and considered the bounds equal
+            if (!isEqualCase)
+                Assert.True(inner != outer);
+
+            // TODO: Also test unbounded 0, 1
+            // Generate a bunch of integers, and record them in a known-series random.
+            var wrapper = new ArchivalWrapper(rng);
+            var (outerBound, dualBound) = GetGenerationFunctions<T>(wrapper, funcName);
+            for (int i = 0; i < 100; i++)
+            {
+                outerBound(outer);
+                dualBound(inner, outer);
+            }
+
+            // Generate each of those numbers from a KSR recording what the actual generator just generated.
+            // Since KSR throws exception if any value is outside the allowable bounds, this validates that the bounds
+            // stay within inner (inclusive) and outer (exclusive).  In the process, we'll also build a frequency
+            // dictionary for the next step.
+            var frequencyDual = new Dictionary<T, int>();
+            var frequencyOuter = new Dictionary<T, int>();
+            var ksr = wrapper.MakeArchivedSeries();
+            (outerBound, dualBound) = GetGenerationFunctions<T>(ksr, funcName);
+            for (int i = 0; i < 100; i++)
+            {
+                T value = outerBound(outer);
+                if (!frequencyOuter.ContainsKey(value))
+                    frequencyOuter[value] = 0;
+                frequencyOuter[value] += 1;
+
+                value = dualBound(inner, outer);
+                if (!frequencyDual.ContainsKey(value))
+                    frequencyDual[value] = 0;
+                frequencyDual[value] += 1;
+            }
+
+            // KSR validates that the numbers don't _exceed_ the bound, but not that all numbers within the bounds
+            // are generated.  But, especially since some implementations of floating point RNG won't be able to
+            // generate all values, there's no easy way to check this.  We'll at least sanity check that there are
+            // multiple values returned though if we're not checking specifically for equality, to ensure bound-crossing
+            // behavior is consistent.  Since the ranges we use are small, there should definitely be at least 2 unique
+            // values out of 100 generated (if not, the generator probably has severe distribution problems).
+            if (isEqualCase)
+            {
+                Assert.Single(frequencyDual);
+                Assert.Single(frequencyOuter);
+                Assert.Equal(outer, frequencyDual.Values.First());
+            }
+            else
+            {
+                Assert.True(frequencyDual.Count > 1);
+                Assert.True(frequencyOuter.Count > 1);
+            }
+        }
         #endregion
 
 
@@ -118,22 +200,70 @@ namespace ShaiRandom.UnitTests
         [Theory]
         [MemberDataTuple(nameof(UnsignedTestData))]
         void NextULong(int inner, int outer, IEnhancedRandom rng)
-            => TestIntegerFunc<ulong>(rng, "NextULong", (inner, outer));
+            => TestIntFunctionBounds<ulong>(rng, "NextULong", (inner, outer));
 
         [Theory]
         [MemberDataTuple(nameof(SignedTestData))]
         void NextLong(int inner, int outer, IEnhancedRandom rng)
-            => TestIntegerFunc<long>(rng, "NextLong", (inner, outer));
+            => TestIntFunctionBounds<long>(rng, "NextLong", (inner, outer));
 
         [Theory]
         [MemberDataTuple(nameof(UnsignedTestData))]
         void NextUInt(int inner, int outer, IEnhancedRandom rng)
-            => TestIntegerFunc<uint>(rng, "NextUInt", (inner, outer));
+            => TestIntFunctionBounds<uint>(rng, "NextUInt", (inner, outer));
 
         [Theory]
         [MemberDataTuple(nameof(SignedTestData))]
         void NextInt(int inner, int outer, IEnhancedRandom rng)
-            => TestIntegerFunc<int>(rng, "NextInt", (inner, outer));
+            => TestIntFunctionBounds<int>(rng, "NextInt", (inner, outer));
+
+        #endregion
+
+        #region Floating-Point Function Tests
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextFloat(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<float>(rng, "NextFloat", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextFloatInclusiveBounds(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<float>(rng, "NextInclusiveFloat", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextFloatExclusiveBounds(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<float>(rng, "NextExclusiveFloat", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextDouble(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<double>(rng, "NextDouble", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextDoubleInclusiveBounds(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<double>(rng, "NextInclusiveDouble", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextDoubleExclusiveBounds(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<double>(rng, "NextExclusiveDouble", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextDecimal(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<decimal>(rng, "NextDecimal", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextDecimalInclusiveBounds(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<decimal>(rng, "NextInclusiveDecimal", (inner, outer));
+
+        [Theory]
+        [MemberDataTuple(nameof(FloatingTestData))]
+        void NextDecimalExclusiveBounds(float inner, float outer, IEnhancedRandom rng)
+            => TestFloatingFunctionBounds<decimal>(rng, "NextExclusiveDecimal", (inner, outer));
         #endregion
     }
 }

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -10,8 +10,8 @@ namespace ShaiRandom.UnitTests
 {
     public class BoundsTests
     {
-        public static IEnumerable<(int inner, int outer)> SignedBounds = new[] { (1, 3), (2, 2), (1, -2) };
-        public static IEnumerable<(int inner, int outer)> UnsignedBounds = new[] { (1, 3), (2, 2) };
+        public static IEnumerable<(int inner, int outer)> SignedBounds = new[] { (1, 3), (2, 2), (-3, -1), (-2, 1), (1, -2) };
+        public static IEnumerable<(int inner, int outer)> UnsignedBounds = new[] { (1, 3), (2, 2), (3, 1) };
 
         private (Func<T, T> outerBound, Func<T, T, T> dualBound) GetGenerationFunctions<T>(IEnhancedRandom rng, string name)
             where T : notnull
@@ -91,10 +91,12 @@ namespace ShaiRandom.UnitTests
             // KSR validates that the numbers don't _exceed_ the bound, but not that all numbers within the bounds
             // are generated.  Therefore, we'll check to ensure the inclusive bounds themselves were both returned
             // (which should happen w/ 100 iterations over a small range).
+            dynamic outerInclusive = bounds.inner < bounds.outer ? outer - 1 :
+                bounds.inner == bounds.outer ? outer : outer + 1;
             Assert.True(frequencyDual.ContainsKey(inner));
-            Assert.True(frequencyDual.ContainsKey(bounds.inner < bounds.outer ? outer - 1 : outer + 1));
+            Assert.True(frequencyDual.ContainsKey(outerInclusive));
             Assert.True(frequencyOuter.ContainsKey((T)Convert.ChangeType(0, typeof(T))));
-            Assert.True(frequencyDual.ContainsKey(bounds.inner < bounds.outer ? outer - 1 : outer + 1));
+            Assert.True(frequencyDual.ContainsKey(outerInclusive));
         }
 
         [Theory]

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -23,7 +23,7 @@ namespace ShaiRandom.UnitTests
         private const float EqualTestValue = 1.2f;
         private static readonly (float inner, float outer)[] s_floatingBounds =
         {
-            (0.000000001f, 0.000000003f), (EqualTestValue, EqualTestValue), (-0.000000003f, -0.000000001f),
+            (0.000000001f, 0.000000003f), (EqualTestValue, EqualTestValue), (0, 0), (-0.000000003f, -0.000000001f),
             (-0.000000001f, 0.000000001f), (0.000000001f, -0.000000001f)
         };
 
@@ -137,7 +137,7 @@ namespace ShaiRandom.UnitTests
 
             // Check if we're explicitly comparing for equality, so we can avoid our sanity check for more than
             // one unique returned value in that case
-            bool isEqualCase =  Math.Abs(bounds.inner - 1.2f) < 0.00000000001;
+            bool isEqualCase =  Math.Abs(bounds.inner - 1.2f) < 0.00000000001 || bounds.inner == 0 && bounds.outer == 0;
 
             // Sanity check to make sure we haven't made the test case data so precise that floating-point imprecision
             // bit us and considered the bounds equal
@@ -184,8 +184,15 @@ namespace ShaiRandom.UnitTests
             if (isEqualCase)
             {
                 Assert.Single(frequencyDual);
-                Assert.Single(frequencyOuter);
-                Assert.Equal(outer, frequencyDual.Values.First());
+                Assert.Equal(outer, frequencyDual.Keys.First());
+
+                if (bounds.inner == 0 && bounds.outer == 0)
+                {
+                    Assert.Single(frequencyOuter);
+                    Assert.Equal(outer, frequencyOuter.Keys.First());
+                }
+                else
+                    Assert.True(frequencyOuter.Count > 1);
             }
             else
             {

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -19,11 +19,11 @@ namespace ShaiRandom.UnitTests
         private static readonly (int inner, int outer)[] s_signedBounds = { (1, 3), (2, 2), (-3, -1), (-2, 1), (1, -2) };
         private static readonly (int inner, int outer)[] s_unsignedBounds = { (1, 3), (2, 2), (3, 1) };
 
-        public static IEnumerable<(IEnhancedRandom rng, (int inner, int outer) bounds)> SignedTestData =
-            s_generators.Combinate(s_signedBounds);
+        public static IEnumerable<(int inner, int outer, IEnhancedRandom rng)> SignedTestData =
+            s_signedBounds.Combinate(s_generators);
 
-        public static IEnumerable<(IEnhancedRandom rng, (int inner, int outer) bounds)> UnsignedTestData =
-            s_generators.Combinate(s_unsignedBounds);
+        public static IEnumerable<(int inner, int outer, IEnhancedRandom rng)> UnsignedTestData =
+            s_unsignedBounds.Combinate(s_generators);
 
         #region Template Tests
         private (Func<T, T> outerBound, Func<T, T, T> dualBound) GetGenerationFunctions<T>(IEnhancedRandom rng, string name)
@@ -117,13 +117,13 @@ namespace ShaiRandom.UnitTests
         #region Integer Function Tests
         [Theory]
         [MemberDataTuple(nameof(UnsignedTestData))]
-        void NextULong(IEnhancedRandom rng, (int inner, int outer) bounds)
-            => TestIntegerFunc<ulong>(rng, "NextULong", bounds);
+        void NextULong(int inner, int outer, IEnhancedRandom rng)
+            => TestIntegerFunc<ulong>(rng, "NextULong", (inner, outer));
 
         [Theory]
         [MemberDataTuple(nameof(SignedTestData))]
-        void NextLong(IEnhancedRandom rng, (int inner, int outer) bounds)
-            => TestIntegerFunc<long>(rng, "NextLong", bounds);
+        void NextLong(int inner, int outer, IEnhancedRandom rng)
+            => TestIntegerFunc<long>(rng, "NextLong", (inner, outer));
         #endregion
     }
 }

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Reflection;
+using ShaiRandom.Generators;
+using ShaiRandom.Wrappers;
+using Xunit;
+
+namespace ShaiRandom.UnitTests
+{
+    public class BoundsTests
+    {
+        private (int inner, int outer) _signedBounds = (1, -2);
+        private (int inner, int outer) _unsignedBounds = (3, 1);
+
+        private (Func<T, T> outerBound, Func<T, T, T> dualBound) GetGenerationFunctions<T>(IEnhancedRandom rng, string name)
+            where T : notnull
+        {
+            // Find info for the functions
+            var outerBoundInfo = typeof(IEnhancedRandom).GetMethod(name, new []{typeof(T)})
+                                 ?? throw new Exception("Couldn't generation method with the name given that takes a single (outer) bound.");
+            var dualBoundInfo = typeof(IEnhancedRandom).GetMethod(name, new []{typeof(T), typeof(T)})
+                                ?? throw new Exception("Couldn't find generation method with the name given which takes both an inner and outer bound.");
+
+            // Create convenient Func wrappers from which we can call them.
+            T OuterBound(T outer)
+            {
+                try
+                {
+                    return (T)outerBoundInfo.Invoke(rng, new object[] { outer })!;
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException!;
+                }
+            }
+
+            T DualBound(T inner, T outer)
+            {
+                try
+                {
+                    return (T)dualBoundInfo.Invoke(rng, new object[] { inner, outer })!;
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException!;
+                }
+            }
+
+            // Return functions
+            return (OuterBound, DualBound);
+        }
+
+        private void TestIntegerFunc<T>(IEnhancedRandom rng, string funcName, (T inner, T outer) bounds)
+            where T : IComparable<T>
+        {
+            // Create dynamic variable for outer so we can add/subtract when checking the bound extents
+            dynamic outerDynamic = bounds.outer;
+
+            // Generate a bunch of integers, and record them in a known-series random.
+            var wrapper = new ArchivalWrapper(rng);
+            var (_, dualBound) = GetGenerationFunctions<T>(wrapper, funcName);
+            for (int i = 0; i < 100; i++)
+                dualBound(bounds.inner, bounds.outer);
+
+            // Generate each of those numbers from a KSR recording what the actual generator just generated.
+            // Since KSR throws exception if any value is outside the allowable bounds, this validates that the bounds
+            // stay within inner (inclusive) and outer (exclusive).  In the process, we'll also build a frequency
+            // dictionary for the next step.
+            var frequencyDict = new Dictionary<T, int>();
+            var ksr = wrapper.MakeArchivedSeries();
+            (_, dualBound) = GetGenerationFunctions<T>(ksr, funcName);
+            for (int i = 0; i < 100; i++)
+            {
+                T value = dualBound(bounds.inner, bounds.outer);
+                if (!frequencyDict.ContainsKey(value))
+                    frequencyDict[value] = 0;
+                frequencyDict[value] += 1;
+            }
+
+            // KSR validates that the numbers don't _exceed_ the bound, but not that all numbers within the bounds
+            // are generated.  Therefore, we'll check to ensure the inclusive bounds themselves were both returned
+            // (which should happen w/ 100 iterations over a small range).
+            Assert.True(frequencyDict.ContainsKey(bounds.inner));
+            Assert.True(frequencyDict.ContainsKey(bounds.inner.CompareTo(bounds.outer) < 0 ? outerDynamic - 1 : outerDynamic + 1));
+
+        }
+
+        // TODO: Bounds
+
+        [Fact]
+        void NextULong() => TestIntegerFunc<ulong>(new MizuchiRandom(), "NextULong", (3, 1));
+
+        [Fact]
+        void NextLong() => TestIntegerFunc<long>(new MizuchiRandom(), "NextLong", (1, -2));
+    }
+}

--- a/ShaiRandom.UnitTests/DataGenerators.cs
+++ b/ShaiRandom.UnitTests/DataGenerators.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using ShaiRandom.Generators;
 using ShaiRandom.Wrappers;
 

--- a/ShaiRandom.UnitTests/DataGenerators.cs
+++ b/ShaiRandom.UnitTests/DataGenerators.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using ShaiRandom.Generators;
+using ShaiRandom.Wrappers;
+
+namespace ShaiRandom.UnitTests
+{
+    /// <summary>
+    /// Some static methods that generate test data, which are used across multiple tests.
+    /// </summary>
+    public static class DataGenerators
+    {
+        /// <summary>
+        /// Creates every generator in the library which qualifies under the given parameters.  It will never
+        /// return a <see cref="KnownSeriesRandom"/>, since that generator is a special case.
+        /// </summary>
+        /// <remarks>
+        /// New generator implementations should be added here to ensure they're unit tested.
+        /// </remarks>
+        /// <param name="includeWrappers">Whether or not to include things in the ShaiRandom.Wrappers namespace.</param>
+        /// <returns>All qualifying generator types in the library.</returns>
+        public static IEnumerable<IEnhancedRandom> CreateGenerators(bool includeWrappers)
+        {
+            yield return new DistinctRandom();
+            yield return new FourWheelRandom();
+            yield return new LaserRandom();
+            yield return new MizuchiRandom();
+            yield return new RomuTrioRandom();
+            yield return new StrangerRandom();
+            yield return new TricycleRandom();
+            yield return new Xoshiro256StarStarRandom();
+
+            if (includeWrappers)
+            {
+                yield return new ArchivalWrapper();
+                yield return new ReversingWrapper();
+                yield return new TRGeneratorWrapper();
+            }
+        }
+    }
+}

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ShaiRandom.Generators;

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ShaiRandom.Generators;
@@ -59,6 +60,7 @@ namespace ShaiRandom.UnitTests
             floatSeries: new []{float.Epsilon, s_floatCloseTo1, 0.0f, 1.0f},
             decimalSeries: new[] { 0.0000000000000000000000000001M, s_decimalCloseTo1, decimal.Zero, decimal.One }
         );
+
         #region Template Tests
 
         private (Func<T> unbounded, Func<T, T> outerBound, Func<T, T> zeroOuterBound, Func<T, T, T> dualBound) GetGenerationFunctions<T>(string name, KnownSeriesRandom unboundedRNG)
@@ -272,7 +274,11 @@ namespace ShaiRandom.UnitTests
             dynamic zero = (T)Convert.ChangeType(0.0, typeof(T));
             T pointOne = (T)Convert.ChangeType(0.1, typeof(T));
             T pointTwo = (T)Convert.ChangeType(0.2, typeof(T));
-            T epsilon = (T)typeof(T).GetField("Epsilon")!.GetValue(null)!;
+            T epsilon = pointOne switch
+            {
+                decimal _ => (T)Convert.ChangeType(0.0000000000000000000000000001M, typeof(T)),
+                _ => (T)typeof(T).GetField("Epsilon")!.GetValue(null)!
+            };
 
             // Get proxies to call the functions we are testing
             var (unbounded, outerBound, zeroOuterBound, dualBound) = GetGenerationFunctions<T>(nameOfFunctionToTest, _unboundedExclusiveRNG);
@@ -301,55 +307,6 @@ namespace ShaiRandom.UnitTests
             // outer == inner is a special case which always returns inner.
             Assert.Equal(value, dualBound(value - pointOne, value + pointOne)); // Allowed range: (value - 0.1, value + 0.1)
             Assert.Equal(value, dualBound(value, value));                       // Allowed range: value
-
-
-            Assert.Throws<ArgumentException>(() => dualBound(value, value + pointOne));            // Allowed range: (value, value + 0.1)
-            Assert.Throws<ArgumentException>(() => dualBound(value, value - pointOne));            // Allowed range: (value - 0.1, value)
-            Assert.Throws<ArgumentException>(() => dualBound(value + pointOne, value + pointTwo)); // Allowed Range: (value + 0.1, value + 0.2)
-            Assert.Throws<ArgumentException>(() => dualBound(value - pointOne, value - pointTwo)); // Allowed Range: (value - 0.2, value - 0.1)
-            Assert.Throws<ArgumentException>(() => dualBound(value + pointOne, value));            // Allowed Range: (value, value + 0.1)
-            Assert.Throws<ArgumentException>(() => dualBound(value - pointOne, value));            // Allowed Range: (value - 0.1, value)
-        }
-        // This is a horrible waste of code, but because Decimal doesn't have an Epsilon field, the existing Floating generator won't work.
-        private void TestDecimalFunctionExclusiveBounds(string nameOfFunctionToTest, decimal maxValueLessThanOne)
-        {
-            // Duck-type the generic type so that we can add/subtract from it using the type's correct operators.
-            decimal value = (decimal)Convert.ChangeType(ReturnedValue, typeof(decimal));
-
-            // Get the correct value types for type T for various constants we use
-            decimal zero = decimal.Zero;
-            decimal pointOne = 0.1M;
-            decimal pointTwo = 0.2M;
-            decimal epsilon = 0.0000000000000000000000000001M;
-
-            // Get proxies to call the functions we are testing
-            var (unbounded, outerBound, zeroOuterBound, dualBound) = GetGenerationFunctions<decimal>(nameOfFunctionToTest, _unboundedExclusiveRNG);
-
-            // Check that the unbounded functions accepts only values within range (0.0, 1.0)
-            Assert.Equal(epsilon, unbounded());
-            Assert.Equal(maxValueLessThanOne, unbounded());
-
-            // NOTE: These two tests assume the state of the generator is still advances even on failure; that is the
-            // case when these were written, but there is no way to validate that in the unit test since the state
-            // is private.
-            Assert.Throws<ArgumentException>(() => unbounded());
-            Assert.Throws<ArgumentException>(() => unbounded());
-
-            // Check that single bound function accepts only range (0.0, outer).
-            // outer == 0.0 is a special case which always returns 0.0.
-            Assert.Equal(value, outerBound(value + pointOne));   // Allowed range: (0.0, value + 0.1)
-            Assert.Equal(zero, zeroOuterBound(zero));            // Allowed range: 0
-
-            Assert.Throws<ArgumentException>(() => zeroOuterBound(value));            // Allowed range: (0.0, value)
-            Assert.Throws<ArgumentException>(() => outerBound(zero - pointOne));      // Allowed range: (-0.1, 0.0]
-            Assert.Throws<ArgumentException>(() => outerBound(value));                // Allowed range: [0.0, value)
-            Assert.Throws<ArgumentException>(() => zeroOuterBound(zero - pointOne)); // Allowed range: (-0.1, 0.0)
-
-            // Check that double bound function accepts only range (inner, outer), even if outer < inner.
-            // outer == inner is a special case which always returns inner.
-            Assert.Equal(value, dualBound(value - pointOne, value + pointOne)); // Allowed range: (value - 0.1, value + 0.1)
-            Assert.Equal(value, dualBound(value, value));                       // Allowed range: value
-
 
             Assert.Throws<ArgumentException>(() => dualBound(value, value + pointOne));            // Allowed range: (value, value + 0.1)
             Assert.Throws<ArgumentException>(() => dualBound(value, value - pointOne));            // Allowed range: (value - 0.1, value)
@@ -389,7 +346,7 @@ namespace ShaiRandom.UnitTests
 
         [Fact]
         public void NextDecimalExclusiveBounds()
-            => TestDecimalFunctionExclusiveBounds(nameof(KnownSeriesRandom.NextExclusiveDecimal), s_decimalCloseTo1);
+            => TestFloatingFunctionExclusiveBounds(nameof(KnownSeriesRandom.NextExclusiveDecimal), s_decimalCloseTo1);
 
         [Fact]
         public void NextDoubleBounds()

--- a/ShaiRandom.UnitTests/TestUtils.cs
+++ b/ShaiRandom.UnitTests/TestUtils.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace ShaiRandom.UnitTests
+{
+    /// <summary>
+    /// Static/extension methods to help with creating test variables/enumerables for XUnit
+    /// </summary>
+    public static class TestUtils
+    {
+        /// <summary>
+        /// Creates a tuple of each possible pairing of elements in the enumerables.
+        /// </summary>
+        /// <typeparam name="T1" />
+        /// <typeparam name="T2" />
+        /// <param name="l1" />
+        /// <param name="l2" />
+        /// <returns>Tuples containing every possible (unique) pairing of elements between the two enumerables.</returns>
+        public static IEnumerable<(T1, T2)> Combinate<T1, T2>(this IEnumerable<T1> l1, IEnumerable<T2> l2)
+        {
+            var l2List = l2.ToList();
+            foreach (var x in l1)
+                foreach (var y in l2List)
+                    yield return (x, y);
+        }
+
+        /// <summary>
+        /// Creates a tuple for each pairing of the tuples with the elements from <paramref name="l2" />.
+        /// </summary>
+        /// <typeparam name="T1" />
+        /// <typeparam name="T2" />
+        /// <typeparam name="T3" />
+        /// <param name="tuples" />
+        /// <param name="l2" />
+        /// <returns>
+        /// An enumerable of 3-element tuples that collectively represent every unique pairing of the initial tuples with
+        /// the new values.
+        /// </returns>
+        public static IEnumerable<(T1, T2, T3)> Combinate<T1, T2, T3>(this IEnumerable<(T1 i1, T2 i2)> tuples,
+                                                                      IEnumerable<T3> l2)
+        {
+            var l2List = l2.ToList();
+            foreach (var (i1, i2) in tuples)
+                foreach (var y in l2List)
+                    yield return (i1, i2, y);
+        }
+
+        /// <summary>
+        /// Creates a tuple for each pairing of the tuples with the elements from <paramref name="l2" />.
+        /// </summary>
+        /// <typeparam name="T1" />
+        /// <typeparam name="T2" />
+        /// <typeparam name="T3" />
+        /// <typeparam name="T4" />
+        /// <param name="tuples" />
+        /// <param name="l2" />
+        /// <returns>
+        /// An enumerable of 4-element tuples that collectively represent every unique pairing of the initial tuples with
+        /// the new values.
+        /// </returns>
+        public static IEnumerable<(T1, T2, T3, T4)> Combinate<T1, T2, T3, T4>(this IEnumerable<(T1 i1, T2 i2, T3 i3)> tuples,
+                                                                              IEnumerable<T4> l2)
+        {
+            var l2List = l2.ToList();
+            foreach (var (i1, i2, i3) in tuples)
+                foreach (var y in l2List)
+                    yield return (i1, i2, i3, y);
+        }
+
+        /// <summary>
+        /// Creates a tuple for each pairing of the tuples with the elements from <paramref name="l2" />.
+        /// </summary>
+        /// <typeparam name="T1" />
+        /// <typeparam name="T2" />
+        /// <typeparam name="T3" />
+        /// <typeparam name="T4" />
+        /// <typeparam name="T5" />
+        /// <param name="tuples" />
+        /// <param name="l2" />
+        /// <returns>
+        /// An enumerable of 5-element tuples that collectively represent every unique pairing of the initial tuples with
+        /// the new values.
+        /// </returns>
+        public static IEnumerable<(T1, T2, T3, T4, T5)> Combinate<T1, T2, T3, T4, T5>(this IEnumerable<(T1 i1, T2 i2, T3 i3, T4)> tuples,
+                                                                              IEnumerable<T5> l2)
+        {
+            var l2List = l2.ToList();
+            foreach (var (i1, i2, i3, i4) in tuples)
+                foreach (var y in l2List)
+                    yield return (i1, i2, i3, i4, y);
+        }
+    }
+}


### PR DESCRIPTION
# Changes
- Minor refactor in `KnownSeriesRandomTests` which allows us to avoid duplicating an entire function to support decimal function testing
- Created facilities in the unit tests project for creating one of each type of generator in the library.  Consolidating this to a single function allows the actual unit test classes to share the code, which will limit the amount of modification needed when new generator types are added
- Added a framework to test all `IEnhancedRandom` implementations to ensure they respect the bounds defined by the contract for the interface's functions.
    - The theories involved create a fairly large number of test cases, so it will take a moment to run

# Goals/End-State
The primary goal here is to create an extensible framework that tests the generator implementations within the library, to ensure that they implement the `IEnhancedRandom` contract properly.  I elected to use `KnownSeriesRandom` in the testing process, in order to ensure the bounds checking code already written for it was effectively shared so it wasn't duplicated.

Hopefully, this should allow future generators and modifications to take place with confidence that the `IEnhancedRandom` contract is properly maintained, and as well that the `KnownSeriesRandom` implementation will stay in sync.