### PR TITLE
KnownSeriesRandom Fixes and Unit Tests

### DIFF
--- a/ShaiRandom.UnitTests/BasicTests.cs
+++ b/ShaiRandom.UnitTests/BasicTests.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using ShaiRandom.Generators;
 using Xunit;
-using XUnit.ValueTuples;
 
 namespace ShaiRandom.UnitTests
 {
@@ -113,65 +110,5 @@ namespace ShaiRandom.UnitTests
             Assert.True((biggest - smallest) / (biggest + 0.001) < 0.11);
         }
 
-    }
-
-    public class SerializationTests
-    {
-        private static readonly IEnhancedRandom[] s_generators = DataGenerators.CreateGenerators(true).ToArray();
-        public static IEnumerable<IEnhancedRandom> Generators => s_generators;
-
-        [Theory]
-        [MemberDataEnumerable(nameof(Generators))]
-        public void BasicSerDeserTest(IEnhancedRandom gen)
-        {
-            // Advance state, just to make sure we have a valid generator
-            gen.NextULong();
-
-            // Serialize generator; wrappers have a special-case starting sequence
-            string ser = gen.StringSerialize();
-            Assert.StartsWith(gen.Tag.Length == 1 ? $"{gen.Tag}" : $"#{gen.Tag}`", ser);
-            Assert.EndsWith("`", ser);
-
-            // Deserialize generator
-            var gen2 = AbstractRandom.Deserialize(ser);
-
-            // Check that its state is equivalent and it generates identical numbers
-            Assert.True(gen.Matches(gen2));
-            Assert.Equal(gen.NextULong(), gen2.NextULong());
-        }
-
-        // Needs special serialization tests to ensure that not only its state is the same, but also the series
-        // themselves, which is not represented in the state.
-        [Fact]
-        public void KnownSeriesRandomSerDeserTest()
-        {
-            // Create a KSR with unique series per type
-            var ksr = new KnownSeriesRandom(
-                new[] { 1, 2 }, new[] { 2U, 3U }, new[] { 3.3, 4.4 },
-                new[] { true, false }, new[] { (byte)4, (byte)5 },
-                new[] { 5.5f, 6.6f }, new[] { 6L, 7L }, null, new[] {8.8M, 9.9M}); //new[] { 7UL, 8UL }
-
-            // Advance all states (so the indices are not their starting value)
-            ksr.SetState(1);
-
-            // Serialize generator
-            string ser = ksr.StringSerialize();
-            Assert.StartsWith($"#{ksr.Tag}", ser);
-            Assert.EndsWith("`", ser);
-            // Deserialize generator
-            var ksr2 = (KnownSeriesRandom)AbstractRandom.Deserialize(ser);
-            // Check that its state (indices) are equivalent to the original
-            Assert.True(ksr.Matches(ksr2));
-            // Check that each list is identical
-            Assert.Equal(ksr.IntSeries, ksr2.IntSeries);
-            Assert.Equal(ksr.UIntSeries, ksr2.UIntSeries);
-            Assert.Equal(ksr.DoubleSeries, ksr2.DoubleSeries);
-            Assert.Equal(ksr.BoolSeries, ksr2.BoolSeries);
-            Assert.Equal(ksr.ByteSeries, ksr2.ByteSeries);
-            Assert.Equal(ksr.FloatSeries, ksr2.FloatSeries);
-            Assert.Equal(ksr.LongSeries, ksr2.LongSeries);
-            Assert.Equal(ksr.ULongSeries, ksr2.ULongSeries);
-            Assert.Equal(ksr.DecimalSeries, ksr2.DecimalSeries);
-        }
     }
 }

--- a/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
+++ b/ShaiRandom.UnitTests/KnownSeriesRandomTests.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using ShaiRandom.Generators;
 using Xunit;
 
 namespace ShaiRandom.UnitTests
 {
-    [SuppressMessage("ReSharper", "UselessBinaryOperation")]
     public class KnownSeriesRandomTests
     {
         private const int ReturnedValue = 10;

--- a/ShaiRandom.UnitTests/SerializationTests.cs
+++ b/ShaiRandom.UnitTests/SerializationTests.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ShaiRandom.Generators;
+using Xunit;
+using XUnit.ValueTuples;
+
+namespace ShaiRandom.UnitTests
+{
+    public class SerializationTests
+    {
+        private static readonly IEnhancedRandom[] s_generators = DataGenerators.CreateGenerators(true).ToArray();
+        public static IEnumerable<IEnhancedRandom> Generators => s_generators;
+
+        // All should have unique values per type of series so they can be differentiated.  NextBool should always have
+        // a value
+        public static IEnumerable<KnownSeriesRandom> KSRGenerators = new[]
+        {
+            new KnownSeriesRandom(
+            new[] { 1, 2 }, new[] { 2U, 3U }, new[] { 3.3, 4.4 },
+            new[] { true, false }, new[] { (byte)4, (byte)5 },
+            new[] { 5.5f, 6.6f }, new[] { 6L, 7L }, new[] { 7UL, 8UL }, new[] {8.8M, 9.9M}),
+            new KnownSeriesRandom(
+                new[] { 1, 2 }, null, new[] { 3.3, 4.4 },
+                new[] { true, false }, new[] { (byte)4, (byte)5 },
+                new[] { 5.5f, 6.6f }, new[] { 6L, 7L }, new[] { 7UL, 8UL }, new[] {8.8M, 9.9M}),
+            new KnownSeriesRandom(
+                new[] { 1, 2 }, null, null,
+                new[] { true, false }, new[] { (byte)4, (byte)5 },
+                new[] { 5.5f, 6.6f }, new[] { 6L, 7L }, new[] { 7UL, 8UL }, new[] {8.8M, 9.9M}),
+            new KnownSeriesRandom(
+                null, new[] { 2U, 3U }, new[] { 3.3, 4.4 },
+                new[] { true, false }, new[] { (byte)4, (byte)5 },
+                new[] { 5.5f, 6.6f }, new[] { 6L, 7L }, new[] { 7UL, 8UL }),
+        };
+
+        [Theory]
+        [MemberDataEnumerable(nameof(Generators))]
+        public void BasicSerDeserTest(IEnhancedRandom gen)
+        {
+            // Advance state, just to make sure we have a valid generator
+            gen.NextULong();
+
+            // Serialize generator; wrappers have a special-case starting sequence
+            string ser = gen.StringSerialize();
+            Assert.StartsWith(gen.Tag.Length == 1 ? $"{gen.Tag}" : $"#{gen.Tag}`", ser);
+            Assert.EndsWith("`", ser);
+
+            // Deserialize generator
+            var gen2 = AbstractRandom.Deserialize(ser);
+
+            // Check that its state is equivalent and it generates identical numbers
+            Assert.True(gen.Matches(gen2));
+            Assert.Equal(gen.NextULong(), gen2.NextULong());
+        }
+
+        // Needs special serialization tests to ensure that not only its state is the same, but also the series
+        // themselves, which is not represented in the state.
+        [Theory]
+        [MemberDataEnumerable(nameof(KSRGenerators))]
+        public void KnownSeriesRandomSerDeserTest(KnownSeriesRandom ksr)
+        {
+            // Advance all states (so the indices are not their starting value if they have items)
+            ksr.SetState(1);
+
+            // Serialize generator
+            string ser = ksr.StringSerialize();
+            Assert.StartsWith($"#{ksr.Tag}", ser);
+            Assert.EndsWith("`", ser);
+
+            // Deserialize generator
+            var ksr2 = (KnownSeriesRandom)AbstractRandom.Deserialize(ser);
+            // Check that its state (indices) are equivalent to the original
+            Assert.True(ksr.Matches(ksr2));
+            // Check that each list is identical
+            Assert.Equal(ksr.IntSeries, ksr2.IntSeries);
+            Assert.Equal(ksr.UIntSeries, ksr2.UIntSeries);
+            Assert.Equal(ksr.DoubleSeries, ksr2.DoubleSeries);
+            Assert.Equal(ksr.BoolSeries, ksr2.BoolSeries);
+            Assert.Equal(ksr.ByteSeries, ksr2.ByteSeries);
+            Assert.Equal(ksr.FloatSeries, ksr2.FloatSeries);
+            Assert.Equal(ksr.LongSeries, ksr2.LongSeries);
+            Assert.Equal(ksr.ULongSeries, ksr2.ULongSeries);
+            Assert.Equal(ksr.DecimalSeries, ksr2.DecimalSeries);
+
+            // Sanity check that we can generate a value.
+            ksr2.NextBool();
+        }
+    }
+}

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -404,7 +404,7 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// Returns the next float in the underlying series. The inner bound is always 0. If it is outside of the bound specified, throws an exception.
         /// </summary>
-        /// <param name="outerBound">The louter bound for the returned float, exclusive.</param>
+        /// <param name="outerBound">The outer bound for the returned float, exclusive.</param>
         /// <returns>The next float in the underlying series, if it is within the bound.</returns>
         public float NextFloat(float outerBound) => NextFloat(0f, outerBound);
 
@@ -615,6 +615,7 @@ namespace ShaiRandom.Generators
         ///     - 5: floatSeries
         ///     - 6: longSeries
         ///     - 7: ulongSeries
+        ///     - 8: decimalSeries
         /// </summary>
         /// <param name="selection">Selection value.</param>
         /// <returns>The index of the selected series that will be returned next time that series is used.</returns>
@@ -648,6 +649,7 @@ namespace ShaiRandom.Generators
         ///     - 5: floatSeries
         ///     - 6: longSeries
         ///     - 7: ulongSeries
+        ///     - 8: decimalSeries
         /// </remarks>
         /// <param name="selection">Selection value of index to set.</param>
         /// <param name="value">Value to set the index to.</param>
@@ -822,15 +824,9 @@ namespace ShaiRandom.Generators
                 {
                     ser.Append(item); ser.Append('|');
                 }
-<<<<<<< HEAD
-                ser.Remove(ser.Length - 1, 1);
-            }
-=======
-
                 ser.Remove(ser.Length - 1, 1);
             }
 
->>>>>>> ae6bf48 (Cleanup of serialization code. Added unit test cases for KnownSeriesRandom w/ empty series.)
             ser.Append(lastChar);
         }
 

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -86,7 +86,7 @@ namespace ShaiRandom.Generators
         /// </summary>
         /// <param name="other">Generator to copy state from.</param>
         public KnownSeriesRandom(KnownSeriesRandom other)
-            : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries)
+            : this(other._intSeries, other._uintSeries, other._doubleSeries, other._boolSeries, other._byteSeries, other._floatSeries, other._longSeries, other._ulongSeries, other._decimalSeries)
         {
             _intIndex = other._intIndex;
             _uintIndex = other._uintIndex;
@@ -126,17 +126,17 @@ namespace ShaiRandom.Generators
                                  IEnumerable<long>? longSeries = null, IEnumerable<ulong>? ulongSeries = null,
                                  IEnumerable<decimal>? decimalSeries = null)
         {
-            Seed(0L);
+            _intSeries = intSeries?.ToList() ?? new List<int>();
+            _uintSeries = uintSeries?.ToList() ?? new List<uint>();
+            _longSeries = longSeries?.ToList() ?? new List<long>();
+            _ulongSeries = ulongSeries?.ToList() ?? new List<ulong>();
+            _decimalSeries = decimalSeries?.ToList() ?? new List<decimal>();
+            _doubleSeries = doubleSeries?.ToList() ?? new List<double>();
+            _floatSeries = floatSeries?.ToList() ?? new List<float>();
+            _boolSeries = boolSeries?.ToList() ?? new List<bool>();
+            _byteSeries = byteSeries?.ToList() ?? new List<byte>();
 
-            _intSeries = intSeries == null ? new List<int>() : intSeries.ToList();
-            _uintSeries = uintSeries == null ? new List<uint>() : uintSeries.ToList();
-            _longSeries = longSeries == null ? new List<long>() : longSeries.ToList();
-            _ulongSeries = ulongSeries == null ? new List<ulong>() : ulongSeries.ToList();
-            _decimalSeries = decimalSeries == null ? new List<decimal>() : decimalSeries.ToList();
-            _doubleSeries = doubleSeries == null ? new List<double>() : doubleSeries.ToList();
-            _floatSeries = floatSeries == null ? new List<float>() : floatSeries.ToList();
-            _boolSeries = boolSeries == null ? new List<bool>() : boolSeries.ToList();
-            _byteSeries = byteSeries == null ? new List<byte>() : byteSeries.ToList();
+            Seed(0L);
         }
 
         /// <summary>
@@ -600,16 +600,8 @@ namespace ShaiRandom.Generators
         /// <param name="seed">Index for the sequences.</param>
         public void Seed(ulong seed)
         {
-            int idx = (int)seed;
-            _intIndex = idx;
-            _uintIndex = idx;
-            _doubleIndex = idx;
-            _boolIndex = idx;
-            _byteIndex = idx;
-            _floatIndex = idx;
-            _longIndex = idx;
-            _ulongIndex = idx;
-            _decimalIndex = idx;
+            for (int i = 0; i < StateCount; i++)
+                SetSelectedState(i, 0);
         }
 
         /// <summary>
@@ -639,7 +631,7 @@ namespace ShaiRandom.Generators
                 6 => (ulong)_longIndex,
                 7 => (ulong)_ulongIndex,
                 8 => (ulong)_decimalIndex,
-                _ => throw new ArgumentException("Invalid selector given to SelectState.", nameof(selection))
+                _ => throw new ArgumentException($"Invalid selector given to {nameof(SelectState)}.", nameof(selection))
             };
         }
 
@@ -661,18 +653,38 @@ namespace ShaiRandom.Generators
         /// <param name="value">Value to set the index to.</param>
         public void SetSelectedState(int selection, ulong value)
         {
+            int state = (int)value;
             switch (selection)
             {
-                case 0: _intIndex = (int)value; break;
-                case 1: _uintIndex = (int)value; break;
-                case 2: _doubleIndex = (int)value; break;
-                case 3: _boolIndex = (int)value; break;
-                case 4: _byteIndex = (int)value; break;
-                case 5: _floatIndex = (int)value; break;
-                case 6: _longIndex = (int)value; break;
-                case 7: _ulongIndex = (int)value; break;
-                case 8: _decimalIndex = (int)value; break;
-                default: throw new ArgumentException("Invalid selector given to SetSelectedState.", nameof(selection));
+                case 0:
+                    _intIndex = _intSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _intSeries.Count);
+                    break;
+                case 1:
+                    _uintIndex = _uintSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _uintSeries.Count);
+                    break;
+                case 2:
+                    _doubleIndex = _doubleSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _doubleSeries.Count);
+                    break;
+                case 3:
+                    _boolIndex = _boolSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _boolSeries.Count);
+                    break;
+                case 4:
+                    _byteIndex = _byteSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _byteSeries.Count);
+                    break;
+                case 5:
+                    _floatIndex = _floatSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _floatSeries.Count);
+                    break;
+                case 6:
+                    _longIndex = _longSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _longSeries.Count);
+                    break;
+                case 7:
+                    _ulongIndex = _ulongSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _ulongSeries.Count);
+                    break;
+                case 8:
+                    _decimalIndex = _decimalSeries.Count == 0 ? 0 : MathUtils.WrapAround(state, _decimalSeries.Count);
+                    break;
+                default:
+                    throw new ArgumentException("Invalid selector given to SetSelectedState.", nameof(selection));
             }
         }
         /// <summary>

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -670,8 +670,9 @@ namespace ShaiRandom.Generators
                 case 4: _byteIndex = (int)value; break;
                 case 5: _floatIndex = (int)value; break;
                 case 6: _longIndex = (int)value; break;
+                case 7: _ulongIndex = (int)value; break;
                 case 8: _decimalIndex = (int)value; break;
-                default: _ulongIndex = (int)value; break;
+                default: throw new ArgumentException("Invalid selector given to SetSelectedState.", nameof(selection));
             }
         }
         /// <summary>

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -730,88 +730,75 @@ namespace ShaiRandom.Generators
             _intIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _intSeries.Clear();
             var seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _intSeries.Add(int.Parse(numData));
-            }
+
             // UInt
             _uintIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _uintSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _uintSeries.Add(uint.Parse(numData));
-            }
+
             // Double
             _doubleIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _doubleSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _doubleSeries.Add(double.Parse(numData));
-            }
+
             // Bool
             _boolIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _boolSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _boolSeries.Add(bool.Parse(numData));
-            }
+
             // Byte
             _byteIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _byteSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _byteSeries.Add(byte.Parse(numData));
-            }
 
             // Float
             _floatIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _floatSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _floatSeries.Add(float.Parse(numData));
-            }
 
             // Long
             _longIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _longSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _longSeries.Add(long.Parse(numData));
-            }
-            
+
             // ULong
             _ulongIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _ulongSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1)));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _ulongSeries.Add(ulong.Parse(numData));
-            }
+
             // Decimal
             _decimalIndex = int.Parse(data.Slice(idx + 1, -1 - idx + (idx = data.IndexOf('~', idx + 1))));
             _decimalSeries.Clear();
             seriesData = data.Slice(idx + 1, -1 - idx + data.IndexOf('`', idx + 1));
-            if (!seriesData.IsEmpty)
-            {
-                foreach (var numData in seriesData.Tokenize('|'))
+            foreach (var numData in seriesData.Tokenize('|'))
+                if (!numData.IsEmpty)
                     _decimalSeries.Add(decimal.Parse(numData));
-            }
-            return this;
 
+            return this;
         }
 
         private void SerializeList<T>(StringBuilder ser, IReadOnlyList<T> series, char lastChar = '~')
@@ -822,8 +809,15 @@ namespace ShaiRandom.Generators
                 {
                     ser.Append(item); ser.Append('|');
                 }
+<<<<<<< HEAD
                 ser.Remove(ser.Length - 1, 1);
             }
+=======
+
+                ser.Remove(ser.Length - 1, 1);
+            }
+
+>>>>>>> ae6bf48 (Cleanup of serialization code. Added unit test cases for KnownSeriesRandom w/ empty series.)
             ser.Append(lastChar);
         }
 


### PR DESCRIPTION
# Changed
- Code/docs cleanup in `KnownSeriesRandom`
- Moved if-check for empty span to the inside of foreach loop in the `KnownSeriesRandom.StringDeserialize` function.  This should be slightly more resistant to bad inputs
- Fixed bug in copy-constructor for `KnownSeriesRandom` where it wasn't passing the `_decimalSeries` from the source generator along 
- Ensured `SetState` can't be used to set invalid indices
    - Wraps to the corresponding lists's `Count` value if the list is non-empty; sets 0 instead of the given value if the list is empty.

# Goals/End State
Mostly just code cleanup and bugfixes.  The only major functionality change is to the `SetSelectedState` and `SetState` type functions of `KnownSeriesRandom`.

First, supplying an invalid state selection to KSR's `SetSelectedState` now throws `ArgumentException`.  In KSR's case, this is more consistent with its other behavior for other functions, and is I believe necessary to ensure the unit tests are safe if future modifications to states are made.  This _does_ differ from other generators, which have a `default` switch case wherein a selection which is not explicitly specified is rounded down to the highest value that is valid.  Personally I'm not a fan of this behavior at all; I'd much prefer to get an exception in these cases, because I can't think of any use cases where rounding down is actually useful; in fact the only case I can think of where a user might specify an invalid selection at all is if they created a bug, perhaps by trying to accidentally set or get states based on another generator of a different type; and I'd much rather catch a bug early than continue by doing something non-obvious that will cause bad behavior later on.  That much said, I elected not to modify the other generator's behavior for their state-related functions; I'll leave that decision up to you.  In any case, for the sake of KSR, it is much more consistent with its other behavior, and since KSR's are usually used to replicate well-defined states, it makes more sense to me in this particular case regardless of the others, since in the overwhelming majority of uses cases for KSR (100% of the cases I can think of), setting to an invalid selector is an indication of a bug.

More importantly, the state functions now wrap the specified index to the count of the corresponding series.  This is beneficial for a few reasons:
1. It prevents setting a generator to an invalid state that will crash other functions; something that generally can't happen with traditional generator implementations
2. It ensures that generators which are functionally identical are viewed as identical if you only look at their state
3. It allows `SetState(x)` to be interpreted as "set any indices that can be set to x to x", which for KSR is useful because some of the series may be null.  For example, the unit tests for KSR serialization use this function to advance all applicable states.

I also fixed a bug with the KSR constructor which takes another KSR; it simply wasn't passing the `_decimalSeries` value along.