### PR TITLE
Implemented MinRandom and MaxRandom

### DIFF
--- a/ShaiRandom.PerformanceTests/Benchmarks.cs
+++ b/ShaiRandom.PerformanceTests/Benchmarks.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using ShaiRandom.Generators;
 using Troschuetz.Random.Generators;
@@ -49,8 +48,8 @@ namespace ShaiRandom.PerformanceTests
     /// </summary>
     public class RandomUIntComparison
     {
-        private IEnhancedRandom _rng;
-        private IGenerator _gen;
+        private IEnhancedRandom _rng = null!;
+        private IGenerator _gen = null!;
 
         [GlobalSetup(Target = nameof(Distinct))]
         public void DistinctSetup() => _rng = new DistinctRandom(1UL);
@@ -173,20 +172,20 @@ namespace ShaiRandom.PerformanceTests
     /// </summary>
     public class RandomUIntBoundedComparison
     {
-        private IEnhancedRandom _rng;
-        private IGenerator _gen;
+        private IEnhancedRandom _rng = null!;
+        private IGenerator _gen = null!;
 
 #if NET6_0_OR_GREATER
-        private System.Random _seededRandom;
-        private System.Random _unseededRandom;
+        private System.Random _seededRandom = null!;
+        private System.Random _unseededRandom = null!;
 
         [GlobalSetup(Target = nameof(Seeded))]
-        public void SeededSetup() => _seededRandom = new Random(1);
+        public void SeededSetup() => _seededRandom = new System.Random(1);
         [Benchmark]
         public int Seeded() => _seededRandom.Next(999);
 
         [GlobalSetup(Target = nameof(Unseeded))]
-        public void UnseededSetup() => _unseededRandom = new Random();
+        public void UnseededSetup() => _unseededRandom = new System.Random();
         [Benchmark]
         public int Unseeded() => _unseededRandom.Next(999);
 #endif
@@ -626,13 +625,13 @@ namespace ShaiRandom.PerformanceTests
         private static double StrangeDouble(MizuchiRandom random)
         {
             long bits = random.NextLong();
-            return BitConverter.Int64BitsToDouble((0x7C10000000000000L + (BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) & -0x0010000000000000L)) | (~bits & 0x000FFFFFFFFFFFFFL));
+            return System.BitConverter.Int64BitsToDouble((0x7C10000000000000L + (System.BitConverter.DoubleToInt64Bits(-0x7FFFFFFFFFFFF001L | bits) & -0x0010000000000000L)) | (~bits & 0x000FFFFFFFFFFFFFL));
         }
         private static double BitsyDouble(MizuchiRandom random)
         {
             ulong bits = random.NextULong();
 #if NETCOREAPP3_0_OR_GREATER
-            return BitConverter.Int64BitsToDouble(1022L - BitOperations.TrailingZeroCount(bits) << 52 | (long)(bits >> 12));
+            return System.BitConverter.Int64BitsToDouble(1022L - BitOperations.TrailingZeroCount(bits) << 52 | (long)(bits >> 12));
 #else
             ulong v = bits;
             long c = 64L;

--- a/ShaiRandom.PerformanceTests/Benchmarks.cs
+++ b/ShaiRandom.PerformanceTests/Benchmarks.cs
@@ -310,11 +310,11 @@ namespace ShaiRandom.PerformanceTests
     ///|            Mizuchi | 1.329 ns | 0.0542 ns | 0.0603 ns | 1.291 ns |
     ///|               Trim | 1.381 ns | 0.0584 ns | 0.1294 ns | 1.347 ns |
     ///
-    /// 
+    ///
     /// </summary>
     public class RandomULongComparison
     {
-        private IEnhancedRandom _rng;
+        private IEnhancedRandom _rng = null!;
 
         [GlobalSetup(Target = nameof(Distinct))]
         public void DistinctSetup() => _rng = new DistinctRandom(1UL);

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -19,6 +19,9 @@ namespace ShaiRandom.UnitTests
         private static readonly (int inner, int outer)[] s_signedBounds = { (1, 3), (2, 2), (-3, -1), (-2, 1), (1, -2) };
         private static readonly (int inner, int outer)[] s_unsignedBounds = { (1, 3), (2, 2), (3, 1) };
 
+        // Dictionary which includes all types which should be excluded from distribution checks in the below tests
+        private readonly HashSet<Type> _distributionCheckExclusions = new HashSet<Type>{ typeof(MinRandom) };
+
         private const int NumValuesToGenerate = 100;
 
         // MUST be different than values used in other sets.
@@ -130,6 +133,8 @@ namespace ShaiRandom.UnitTests
                 frequencyDual[value]++;
             }
 
+            if (_distributionCheckExclusions.Contains(rng.GetType())) return;
+
             // KSR validates that the numbers don't _exceed_ the bound, but not that all numbers within the bounds
             // are generated.  Therefore, we'll check to ensure the inclusive bounds themselves were both returned
             // (which should happen w/ 100 iterations over a small range).
@@ -192,6 +197,8 @@ namespace ShaiRandom.UnitTests
                 frequencyDual[value]++;
             }
 
+            if (_distributionCheckExclusions.Contains(rng.GetType())) return;
+
             // KSR validates that the numbers don't _exceed_ the bound, but not that all numbers within the bounds
             // are generated.  But, especially since some implementations of floating point RNG won't be able to
             // generate all values, there's no easy way to check this.  We'll at least sanity check that there are
@@ -246,6 +253,8 @@ namespace ShaiRandom.UnitTests
                     frequency[value] = 0;
                 frequency[value]++;
             }
+
+            if (_distributionCheckExclusions.Contains(rng.GetType())) return;
 
             // KSR validates that the numbers don't _exceed_ the bound, but not that all numbers within the bounds
             // are generated.  But, especially since some implementations of floating point RNG won't be able to

--- a/ShaiRandom.UnitTests/BoundsTests.cs
+++ b/ShaiRandom.UnitTests/BoundsTests.cs
@@ -20,7 +20,7 @@ namespace ShaiRandom.UnitTests
         private static readonly (int inner, int outer)[] s_unsignedBounds = { (1, 3), (2, 2), (3, 1) };
 
         // Dictionary which includes all types which should be excluded from distribution checks in the below tests
-        private readonly HashSet<Type> _distributionCheckExclusions = new HashSet<Type>{ typeof(MinRandom) };
+        private readonly HashSet<Type> _distributionCheckExclusions = new HashSet<Type>{ typeof(MinRandom), typeof(MaxRandom) };
 
         private const int NumValuesToGenerate = 100;
 

--- a/ShaiRandom.UnitTests/DataGenerators.cs
+++ b/ShaiRandom.UnitTests/DataGenerators.cs
@@ -29,6 +29,7 @@ namespace ShaiRandom.UnitTests
             yield return new TricycleRandom();
             yield return new Xoshiro256StarStarRandom();
             yield return new TrimRandom();
+            yield return new MinRandom();
 
             if (includeWrappers)
             {

--- a/ShaiRandom.UnitTests/DataGenerators.cs
+++ b/ShaiRandom.UnitTests/DataGenerators.cs
@@ -30,6 +30,7 @@ namespace ShaiRandom.UnitTests
             yield return new Xoshiro256StarStarRandom();
             yield return new TrimRandom();
             yield return new MinRandom();
+            yield return new MaxRandom();
 
             if (includeWrappers)
             {

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -16,8 +16,16 @@ namespace ShaiRandom.Generators
     /// </remarks>
     public abstract class AbstractRandom : IEnhancedRandom
     {
-        private static readonly float s_floatAdjust = MathF.Pow(2f, -24f);
-        private static readonly double s_doubleAdjust = Math.Pow(2.0, -53.0);
+        /// <summary>
+        /// 2^-24; used in the process of creating a single-precision floating point value in range [0, 1) based on a ulong.
+        /// </summary>
+        public static readonly float FloatAdjust = MathF.Pow(2f, -24f);
+
+        /// <summary>
+        /// 2^-53; used in the process of creating a double-precision floating point value in range [0, 1) based on a ulong.
+        /// </summary>
+        public static readonly double DoubleAdjust = Math.Pow(2.0, -53.0);
+
         /// <summary>
         /// Used by <see cref="MakeSeed"/> to produce mid-low quality random numbers as a starting seed, as a "don't care" option for seeding.
         /// </summary>
@@ -309,7 +317,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public virtual float NextFloat()
         {
-            return (NextULong() >> 40) * s_floatAdjust;
+            return (NextULong() >> 40) * FloatAdjust;
         }
 
         /// <inheritdoc />
@@ -328,7 +336,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public virtual double NextDouble()
         {
-            return (NextULong() >> 11) * s_doubleAdjust;
+            return (NextULong() >> 11) * DoubleAdjust;
         }
 
         /// <inheritdoc />
@@ -346,7 +354,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public virtual double NextInclusiveDouble()
         {
-            return NextULong(0x20000000000001L) * s_doubleAdjust;
+            return NextULong(0x20000000000001L) * DoubleAdjust;
         }
 
         /// <inheritdoc />
@@ -364,7 +372,7 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public virtual float NextInclusiveFloat()
         {
-            return NextInt(0x1000001) * s_floatAdjust;
+            return NextInt(0x1000001) * FloatAdjust;
         }
 
         /// <inheritdoc />

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
 using ShaiRandom.Wrappers;
@@ -434,6 +435,7 @@ namespace ShaiRandom.Generators
         }
 
         /// <inheritdoc />
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public double NextExclusiveDouble(double innerBound, double outerBound)
         {
             double v = innerBound + NextDouble() * (outerBound - innerBound);
@@ -456,6 +458,7 @@ namespace ShaiRandom.Generators
         }
 
         /// <inheritdoc />
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public float NextExclusiveFloat(float innerBound, float outerBound)
         {
             float v = innerBound + NextFloat() * (outerBound - innerBound);

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -134,14 +134,14 @@ namespace ShaiRandom.Generators
         /// <returns>A newly-allocated IEnhancedRandom matching the implementation and state of the serialized AbstractRandom.</returns>
         public static IEnhancedRandom Deserialize(ReadOnlySpan<char> data)
         {
-            if (data.Length <= 3)
+            int idx = data.IndexOf('`');
+            if (idx == -1)
                 throw new ArgumentException("String given cannot represent a valid generator.");
 
             // Can't use Span as the key in a dictionary, so we have to allocate a string to perform the lookup.
             // When the feature linked here is implemented, we could get around this:
             // https://github.com/dotnet/runtime/issues/27229
-            int idx = data.IndexOf('`');
-            string tagData = new string(data.Slice(0, idx));
+            string tagData = new string(data[..idx]);
             return TAGS[tagData].Copy().StringDeserialize(data[idx..]);
         }
 

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -183,25 +183,25 @@ namespace ShaiRandom.Generators
             if (compareResult > 0)
             {
                 if (value.CompareTo(innerValue) < 0)
-                    throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                    throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
 
                 if (value.CompareTo(outerValue) >= 0)
-                    throw new ArgumentException("Value returned is above the bounds of the generator function call.");
+                    throw new ArgumentException($"Value {value} was returned, but that is above the bounds of the generator function call.");
             }
             // inner == outer; there is only one valid value
             else if (compareResult == 0)
             {
                 if (value.CompareTo(innerValue) != 0)
-                    throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                    throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
             }
             // outer < inner; but outer is still _exclusive_, inner is _inclusive_
             else
             {
                 if (value.CompareTo(outerValue) <= 0)
-                    throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                    throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
 
                 if (value.CompareTo(innerValue) > 0)
-                    throw new ArgumentException("Value returned is above the bounds of the generator function call.");
+                    throw new ArgumentException($"Value {value} was returned, but that is above the bounds of the generator function call.");
             }
 
             return value;
@@ -216,16 +216,16 @@ namespace ShaiRandom.Generators
             if (min.CompareTo(max) == 0)
             {
                 if (value.CompareTo(min) != 0)
-                    throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                    throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
 
                 return value; // If bounds are the same, the bound is returned.
             }
 
             if (value.CompareTo(min) <= 0)
-                throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
 
             if (value.CompareTo(max) >= 0)
-                throw new ArgumentException("Value returned is above the bounds of the generator function call.");
+                throw new ArgumentException($"Value {value} was returned, but that is above the bounds of the generator function call.");
 
             return value;
         }
@@ -237,13 +237,13 @@ namespace ShaiRandom.Generators
             var (min, max) = GetMinAndMax(innerValue, outerValue);
 
             if (min.CompareTo(max) == 0 && value.CompareTo(min) != 0)
-                throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
 
             if (value.CompareTo(min) < 0)
-                throw new ArgumentException("Value returned is below the bounds of the generator function call.");
+                throw new ArgumentException($"Value {value} was returned, but that is below the bounds of the generator function call.");
 
             if (value.CompareTo(max) > 0)
-                throw new ArgumentException("Value returned is above the bounds of the generator function call.");
+                throw new ArgumentException($"Value {value} was returned, but that is above the bounds of the generator function call.");
 
             return value;
         }

--- a/ShaiRandom/Generators/MaxRandom.cs
+++ b/ShaiRandom/Generators/MaxRandom.cs
@@ -239,35 +239,11 @@ namespace ShaiRandom.Generators
         /// <returns>1.0f - <see cref="AbstractRandom.FloatAdjust"/></returns>
         public float NextFloat() => 1.0f - AbstractRandom.FloatAdjust;
 
-        /// <summary>
-        /// Returns the maximum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
-        /// </summary>
-        /// <remarks>
-        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float)"/>
-        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
-        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
-        /// </remarks>
-        /// <param name="outerBound"/>
-        /// <returns>The maximum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextFloat(float outerBound) => NextFloat(0, outerBound);
 
-        /// <summary>
-        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
-        /// </summary>
-        /// <remarks>
-        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float, float)"/>
-        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
-        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
-        /// </remarks>
-        /// <param name="innerBound"/>
-        /// <param name="outerBound"/>
-        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextFloat(float innerBound, float outerBound)
         {
-            // Note: this breaks exclusivity with, for example innerBound=1.8f and outerBound=1.9f (it returns 1.9f);
-            // but the AbstractRandom implementation can as well
-            var startingVal = innerBound <= outerBound ? NextFloat() : 0f;
-            return innerBound + startingVal * (outerBound - innerBound);
+            throw new NotImplementedException();
         }
 
         public double NextDouble() => throw new NotImplementedException();

--- a/ShaiRandom/Generators/MaxRandom.cs
+++ b/ShaiRandom/Generators/MaxRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ShaiRandom.Generators
 {
@@ -224,74 +225,295 @@ namespace ShaiRandom.Generators
         /// <returns>True</returns>
         public bool NextBool() => true;
 
-
-
-
-
-
-
-
-
-
         /// <summary>
         /// Always returns 1.0f - <see cref="AbstractRandom.FloatAdjust"/>.
         /// </summary>
         /// <returns>1.0f - <see cref="AbstractRandom.FloatAdjust"/></returns>
         public float NextFloat() => 1.0f - AbstractRandom.FloatAdjust;
 
+        /// <summary>
+        /// Returns the maximum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextFloat(float outerBound) => NextFloat(0, outerBound);
 
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float, float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextFloat(float innerBound, float outerBound)
         {
-            throw new NotImplementedException();
+            // Note: this breaks exclusivity with, for example innerBound=1.8f and outerBound=1.9f (it returns 1.9f);
+            // but the AbstractRandom implementation can as well
+            var startingVal = innerBound <= outerBound ? NextFloat() : 0f;
+            return innerBound + startingVal * (outerBound - innerBound);
         }
 
-        public double NextDouble() => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 1.0 - AbstractRandom.DoubleAdjust.
+        /// </summary>
+        /// <returns>1.0 - AbstractRandom.DoubleAdjust</returns>
+        public double NextDouble() => 1.0 - AbstractRandom.DoubleAdjust;
 
-        public double NextDouble(double outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0.0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDouble(double)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public double NextDouble(double outerBound) => NextDouble(0, outerBound);
 
-        public double NextDouble(double innerBound, double outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDouble(double, double)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public double NextDouble(double innerBound, double outerBound)
+        {
+            // Note: this breaks exclusivity with, for example innerBound=1.8 and outerBound=1.9 (it returns 1.9);
+            // but the AbstractRandom implementation can as well
+            var startingVal = innerBound <= outerBound ? NextDouble() : 0.0;
+            return innerBound + startingVal * (outerBound - innerBound);
+        }
 
-        public decimal NextDecimal() => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 0.9999999999999999999999999999M.
+        /// </summary>
+        /// <returns>0.9999999999999999999999999999M</returns>
+        public decimal NextDecimal() => 0.9999999999999999999999999999M;
 
-        public decimal NextDecimal(decimal outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0.0M and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDecimal(decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0M and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public decimal NextDecimal(decimal outerBound) => NextDecimal(0, outerBound);
 
-        public decimal NextDecimal(decimal innerBound, decimal outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDecimal(decimal, decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public decimal NextDecimal(decimal innerBound, decimal outerBound)
+        {
+            {
+                unchecked
+                {
+                    ulong bits = innerBound <= outerBound ? 0x204fce5e3e250261UL : 0;
+                    var decimalValue = new decimal((int)NextBits(28), (int)(bits & 0xFFFFFFFFUL), (int)(bits >> 32), false, 28);
 
-        public double NextInclusiveDouble() => throw new NotImplementedException();
+                    return innerBound + decimalValue * (outerBound - innerBound);
+                }
+            }
+        }
 
-        public double NextInclusiveDouble(double outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 1.0.
+        /// </summary>
+        /// <returns>1.0</returns>
+        public double NextInclusiveDouble() => 1.0;
 
-        public double NextInclusiveDouble(double innerBound, double outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0.0 and the defined bound.
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0 and the defined bound</returns>
+        public double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0, outerBound);
 
-        public float NextInclusiveFloat() => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of the defined bounds.
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds</returns>
+        public double NextInclusiveDouble(double innerBound, double outerBound) => Math.Max(innerBound, outerBound);
 
-        public float NextInclusiveFloat(float outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 1.0f.
+        /// </summary>
+        /// <returns>1.0f</returns>
+        public float NextInclusiveFloat() => 1.0f;
 
-        public float NextInclusiveFloat(float innerBound, float outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0.0f and the defined bound.
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0f and the defined bound</returns>
+        public float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0f, outerBound);
 
-        public decimal NextInclusiveDecimal() => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of the defined bounds.
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds</returns>
+        public float NextInclusiveFloat(float innerBound, float outerBound) => MathF.Max(innerBound, outerBound);
 
-        public decimal NextInclusiveDecimal(decimal outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 1.0M.
+        /// </summary>
+        /// <returns>1.0M</returns>
+        public decimal NextInclusiveDecimal() => 1.0M;
 
-        public decimal NextInclusiveDecimal(decimal innerBound, decimal outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0.0M and the defined bound.
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0M and the defined bound</returns>
+        public decimal NextInclusiveDecimal(decimal outerBound) => NextInclusiveDecimal(0M, outerBound);
 
-        public double NextExclusiveDouble() => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of the defined bounds.
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds</returns>
+        public decimal NextInclusiveDecimal(decimal innerBound, decimal outerBound) => Math.Max(innerBound, outerBound);
 
-        public double NextExclusiveDouble(double outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 1.0 - AbstractRandom.DoubleAdjust.
+        /// </summary>
+        /// <returns>1.0 - AbstractRandom.DoubleAdjust</returns>
+        public double NextExclusiveDouble() => NextDouble();
 
-        public double NextExclusiveDouble(double innerBound, double outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDouble(double)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
+        public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0.0, outerBound);
 
-        public float NextExclusiveFloat() => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering both bounds to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDouble(double, double)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering both bounds to be exclusive)</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+        public double NextExclusiveDouble(double innerBound, double outerBound)
+        {
+            double nextDouble = innerBound >= outerBound ? 0 : NextDouble();
+            double v = innerBound + nextDouble * (outerBound - innerBound);
+            if (v >= Math.Max(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(Math.Max(innerBound, outerBound)) - 1L);
+            if (v <= Math.Min(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(Math.Min(innerBound, outerBound)) + 1L);
+            return v;
+        }
 
-        public float NextExclusiveFloat(float outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 1.0f - AbstractRandom.FloatAdjust.
+        /// </summary>
+        /// <returns>1.0 - AbstractRandom.FloatAdjust</returns>
+        public float NextExclusiveFloat() => NextFloat();
 
-        public float NextExclusiveFloat(float innerBound, float outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveFloat(float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
+        public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
 
-        public decimal NextExclusiveDecimal() => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveFloat(float, float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> or <paramref name="innerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
+        public float NextExclusiveFloat(float innerBound, float outerBound)
+        {
+            float nextFloat = innerBound >= outerBound ? 0f : 1.0f - AbstractRandom.FloatAdjust;
+            float v = innerBound + nextFloat * (outerBound - innerBound);
+            if (v >= Math.Max(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int32BitsToSingle(BitConverter.SingleToInt32Bits(Math.Max(innerBound, outerBound)) - 1);
+            if (v <= Math.Min(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int32BitsToSingle(BitConverter.SingleToInt32Bits(Math.Min(innerBound, outerBound)) + 1);
+            return v;
+        }
 
-        public decimal NextExclusiveDecimal(decimal outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Always returns 0.9999999999999999999999999999M.
+        /// </summary>
+        /// <returns>0.9999999999999999999999999999M</returns>
+        public decimal NextExclusiveDecimal() => NextDecimal();
 
-        public decimal NextExclusiveDecimal(decimal innerBound, decimal outerBound) => throw new NotImplementedException();
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDecimal(decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
+        public decimal NextExclusiveDecimal(decimal outerBound) => NextExclusiveDecimal(0M, outerBound);
+
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDecimal(decimal, decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
+        public decimal NextExclusiveDecimal(decimal innerBound, decimal outerBound)
+        {
+            unchecked
+            {
+                ulong bits = innerBound <= outerBound ? 0x204fce5e3e250261UL : 0;
+                var decimalValue = new decimal(0xFFFFFFF, (int)(bits & 0xFFFFFFFFUL), (int)(bits >> 32), false, 28);
+
+                return innerBound + decimalValue * (outerBound - innerBound);
+            }
+        }
     }
 }

--- a/ShaiRandom/Generators/MaxRandom.cs
+++ b/ShaiRandom/Generators/MaxRandom.cs
@@ -1,0 +1,321 @@
+﻿using System;
+
+namespace ShaiRandom.Generators
+{
+    /// <summary>
+    /// A "random" number generator which implements all generation functions such that they return the maximum possible
+    /// value that could be returned by an actual generator implementing the <see cref="IEnhancedRandom"/> contract.
+    /// For example, MaxRandom.NextULong() always returns <see cref="ulong.MaxValue"/>,
+    /// MaxRandom.NextULong(1, 3) always returns 2, and so on.
+    /// </summary>
+    /// <remarks>
+    /// This generator can be useful for unit testing or debugging algorithms that use random number generators, since
+    /// bugs involving improper bounds tend to show up at either extreme of valid bounds.
+    ///
+    /// Although this generator does not inherit from <see cref="AbstractRandom"/>, it uses the same conceptual processes
+    /// for determining min and max numbers that can be returned; so in terms of how exclusive bounds are handled, this
+    /// generator performs identically to the theoretical maximums for the same values in an AbstractRandom.
+    /// </remarks>
+    public class MaxRandom : IEnhancedRandom
+    {
+        /// <summary>
+        /// Static instance of this generator that can be used in most cases to prevent allocation, since this generator
+        /// has no associated state.
+        /// </summary>
+        public static readonly MaxRandom Instance = new MaxRandom();
+
+        /// <inheritdoc />
+        public int StateCount => 0;
+
+        /// <summary>
+        /// Doesn't support reading state, since there is no state to read.
+        /// </summary>
+        public bool SupportsReadAccess => false;
+
+        /// <summary>
+        /// Doesn't support setting state, since there is no state to set.
+        /// </summary>
+        public bool SupportsWriteAccess => false;
+
+        /// <summary>
+        /// Supports <see cref="Skip"/>.
+        /// </summary>
+        public bool SupportsSkip => true;
+
+        /// <summary>
+        /// Supports <see cref="IEnhancedRandom.PreviousULong"/>.
+        /// </summary>
+        public bool SupportsPrevious => true;
+
+        /// <summary>
+        /// Tag for this case is "MinR".
+        /// </summary>
+        public string Tag => "MaxR";
+
+        static MaxRandom()
+        {
+            AbstractRandom.RegisterTag(new MaxRandom());
+        }
+
+        /// <summary>
+        /// Returns a new MinRandom generator; this must be equivalent to the current one, since there is no state.
+        /// </summary>
+        /// <returns>A new MinRandom generator.</returns>
+        public IEnhancedRandom Copy() => new MaxRandom();
+
+        /// <inheritdoc />
+        public string StringSerialize() => $"#{Tag}``";
+
+        /// <inheritdoc />
+        public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data) => Instance;
+
+        /// <summary>
+        /// Not supported; this generator has no state.
+        /// </summary>
+        /// <param name="selection"/>
+        public ulong SelectState(int selection) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Not supported; this generator has no state.
+        /// </summary>
+        /// <param name="selection"/>
+        /// <param name="value"/>
+        public void SetSelectedState(int selection, ulong value) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Does nothing, since this generator has no state.
+        /// </summary>
+        /// <param name="seed"/>
+        public void Seed(ulong seed)
+        { }
+
+        /// <summary>
+        /// Does nothing since the return value is always predetermined based on the parameters or implicit bounds.
+        /// </summary>
+        /// <param name="distance"/>
+        /// <returns><see cref="ulong.MaxValue"/>.</returns>
+        public ulong Skip(ulong distance) => NextULong();
+
+        /// <summary>
+        /// Does nothing, since this generator has no state.  Always returns <see cref="ulong.MaxValue"/>.
+        /// </summary>
+        /// <returns><see cref="ulong.MaxValue"/></returns>
+        public ulong PreviousULong() => NextULong();
+
+        /// <summary>
+        /// Always returns <see cref="ulong.MaxValue"/>.
+        /// </summary>
+        /// <returns><see cref="ulong.MaxValue"/>.</returns>
+        public ulong NextULong() => ulong.MaxValue;
+
+        /// <summary>
+        /// Always returns <see cref="long.MaxValue"/>.
+        /// </summary>
+        /// <returns><see cref="long.MaxValue"/>.</returns>
+        public long NextLong() => long.MaxValue;
+
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive).
+        /// </summary>
+        /// <param name="bound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive)</returns>
+        public ulong NextULong(ulong bound) => NextULong(0, bound);
+
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public long NextLong(long outerBound) => NextLong(0, outerBound);
+
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outer"/> to be exclusive).
+        /// </summary>
+        /// <param name="inner"/>
+        /// <param name="outer"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outer"/> to be exclusive)</returns>
+        public ulong NextULong(ulong inner, ulong outer)
+        {
+            // Special case
+            if (inner == outer) return inner;
+
+            // Exclusive bound; round outer toward inner and take the maximum inclusive bound
+            return Math.Max(inner, outer > inner ? outer - 1 : outer + 1);
+        }
+
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outer"/> to be exclusive).
+        /// </summary>
+        /// <param name="inner"/>
+        /// <param name="outer"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outer"/> to be exclusive)</returns>
+        public long NextLong(long inner, long outer)
+        {
+            // Special case
+            if (inner == outer) return inner;
+
+            // Exclusive bound; round toward inner and take the maximum inclusive bound
+            outer = outer < inner ? outer + 1 : outer - 1;
+            return Math.Max(inner, outer);
+        }
+
+        /// <summary>
+        /// Returns a value with the least significant <paramref name="bits"/> % 32 bits set.
+        /// </summary>
+        /// <param name="bits"/>
+        /// <returns>A value with the least significant <paramref name="bits"/> % 32 bits set.</returns>
+        public uint NextBits(int bits) => (uint)(1 << (bits % 32)) - 1;
+
+        /// <summary>
+        /// Fills the buffer with <see cref="byte.MaxValue"/>.
+        /// </summary>
+        /// <param name="bytes">The buffer to fill.</param>
+        public void NextBytes(Span<byte> bytes)
+        {
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = byte.MaxValue;
+        }
+
+        /// <summary>
+        /// Always returns <see cref="int.MaxValue"/>.
+        /// </summary>
+        /// <returns><see cref="int.MaxValue"/>.</returns>
+        public int NextInt() => int.MaxValue;
+
+        /// <summary>
+        /// Always returns <see cref="uint.MaxValue"/>.
+        /// </summary>
+        /// <returns><see cref="uint.MaxValue"/>.</returns>
+        public uint NextUInt() => uint.MaxValue;
+
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive).
+        /// </summary>
+        /// <param name="bound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive)</returns>
+        public uint NextUInt(uint bound) => (uint)NextULong(bound);
+
+        /// <summary>
+        /// Returns the maximum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public int NextInt(int outerBound) => (int)NextLong(outerBound);
+
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public uint NextUInt(uint innerBound, uint outerBound) => (uint)NextULong(innerBound, outerBound);
+
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public int NextInt(int innerBound, int outerBound) => (int)NextLong(innerBound, outerBound);
+
+        /// <summary>
+        /// Always returns true.
+        /// </summary>
+        /// <returns>True</returns>
+        public bool NextBool() => true;
+
+
+
+
+
+
+
+
+
+
+        /// <summary>
+        /// Always returns 1.0f - <see cref="AbstractRandom.FloatAdjust"/>.
+        /// </summary>
+        /// <returns>1.0f - <see cref="AbstractRandom.FloatAdjust"/></returns>
+        public float NextFloat() => 1.0f - AbstractRandom.FloatAdjust;
+
+        /// <summary>
+        /// Returns the maximum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public float NextFloat(float outerBound) => NextFloat(0, outerBound);
+
+        /// <summary>
+        /// Returns the maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float, float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The maximum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public float NextFloat(float innerBound, float outerBound)
+        {
+            // Note: this breaks exclusivity with, for example innerBound=1.8f and outerBound=1.9f (it returns 1.9f);
+            // but the AbstractRandom implementation can as well
+            var startingVal = innerBound <= outerBound ? NextFloat() : 0f;
+            return innerBound + startingVal * (outerBound - innerBound);
+        }
+
+        public double NextDouble() => throw new NotImplementedException();
+
+        public double NextDouble(double outerBound) => throw new NotImplementedException();
+
+        public double NextDouble(double innerBound, double outerBound) => throw new NotImplementedException();
+
+        public decimal NextDecimal() => throw new NotImplementedException();
+
+        public decimal NextDecimal(decimal outerBound) => throw new NotImplementedException();
+
+        public decimal NextDecimal(decimal innerBound, decimal outerBound) => throw new NotImplementedException();
+
+        public double NextInclusiveDouble() => throw new NotImplementedException();
+
+        public double NextInclusiveDouble(double outerBound) => throw new NotImplementedException();
+
+        public double NextInclusiveDouble(double innerBound, double outerBound) => throw new NotImplementedException();
+
+        public float NextInclusiveFloat() => throw new NotImplementedException();
+
+        public float NextInclusiveFloat(float outerBound) => throw new NotImplementedException();
+
+        public float NextInclusiveFloat(float innerBound, float outerBound) => throw new NotImplementedException();
+
+        public decimal NextInclusiveDecimal() => throw new NotImplementedException();
+
+        public decimal NextInclusiveDecimal(decimal outerBound) => throw new NotImplementedException();
+
+        public decimal NextInclusiveDecimal(decimal innerBound, decimal outerBound) => throw new NotImplementedException();
+
+        public double NextExclusiveDouble() => throw new NotImplementedException();
+
+        public double NextExclusiveDouble(double outerBound) => throw new NotImplementedException();
+
+        public double NextExclusiveDouble(double innerBound, double outerBound) => throw new NotImplementedException();
+
+        public float NextExclusiveFloat() => throw new NotImplementedException();
+
+        public float NextExclusiveFloat(float outerBound) => throw new NotImplementedException();
+
+        public float NextExclusiveFloat(float innerBound, float outerBound) => throw new NotImplementedException();
+
+        public decimal NextExclusiveDecimal() => throw new NotImplementedException();
+
+        public decimal NextExclusiveDecimal(decimal outerBound) => throw new NotImplementedException();
+
+        public decimal NextExclusiveDecimal(decimal innerBound, decimal outerBound) => throw new NotImplementedException();
+    }
+}

--- a/ShaiRandom/Generators/MaxRandom.cs
+++ b/ShaiRandom/Generators/MaxRandom.cs
@@ -65,7 +65,7 @@ namespace ShaiRandom.Generators
         public IEnhancedRandom Copy() => new MaxRandom();
 
         /// <inheritdoc />
-        public string StringSerialize() => $"#{Tag}``";
+        public string StringSerialize() => $"{Tag}``";
 
         /// <inheritdoc />
         public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data) => Instance;

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -124,7 +124,7 @@ namespace ShaiRandom.Generators
             if (inner == outer) return inner;
 
             // Exclusive bound; round outer toward inner and take the minimum inclusive bound
-            return Math.Min(inner, outer - 1);
+            return Math.Min(inner, outer > inner ? outer - 1 : outer + 1);
         }
 
         /// <summary>

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -65,7 +65,7 @@ namespace ShaiRandom.Generators
         public IEnhancedRandom Copy() => new MinRandom();
 
         /// <inheritdoc />
-        public string StringSerialize() => $"#{Tag}``";
+        public string StringSerialize() => $"{Tag}``";
 
         /// <inheritdoc />
         public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data) => Instance;

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ShaiRandom.Generators
 {
@@ -414,11 +415,7 @@ namespace ShaiRandom.Generators
         /// </remarks>
         /// <param name="outerBound"/>
         /// <returns>The minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
-        public double NextExclusiveDouble(double outerBound)
-        {
-            ulong value = outerBound < 0 ? ulong.MaxValue : 0;
-            return ((value >> 12) + 1L) * 2.2204460492503126E-16 * outerBound;
-        }
+        public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0.0, outerBound);
 
         /// <summary>
         /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
@@ -430,10 +427,14 @@ namespace ShaiRandom.Generators
         /// <param name="innerBound"/>
         /// <param name="outerBound"/>
         /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public double NextExclusiveDouble(double innerBound, double outerBound)
         {
-            ulong value = outerBound < innerBound ? ulong.MaxValue : 0;
-            return innerBound + ((value >> 12) + 1L) * 2.2204460492503126E-16 * (outerBound - innerBound);
+            double nextDouble = innerBound < outerBound ? 0 : 1.0 - AbstractRandom.DoubleAdjust;
+            double v = innerBound + nextDouble * (outerBound - innerBound);
+            if (v >= Math.Max(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(Math.Max(innerBound, outerBound)) - 1L);
+            if (v <= Math.Min(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int64BitsToDouble(BitConverter.DoubleToInt64Bits(Math.Min(innerBound, outerBound)) + 1L);
+            return v;
         }
 
         /// <summary>
@@ -452,7 +453,7 @@ namespace ShaiRandom.Generators
         /// </remarks>
         /// <param name="outerBound"/>
         /// <returns>The minimum of 1.0842022E-19f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
-        public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0, outerBound);
+        public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
 
         /// <summary>
         /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
@@ -465,12 +466,14 @@ namespace ShaiRandom.Generators
         /// <param name="innerBound"/>
         /// <param name="outerBound"/>
         /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public float NextExclusiveFloat(float innerBound, float outerBound)
         {
-            // Note: this breaks exclusivity with, for example innerBound=1.9f and outerBound=1.8f (it returns 1.8f), same
-            // for innerBound=1.8f and outerBound=1.9f; but the AbstractRandom implementation can as well
-            var startingVal = innerBound > outerBound ? 1.0f - AbstractRandom.FloatAdjust : NextExclusiveFloat();
-            return innerBound + startingVal * (outerBound - innerBound);
+            float nextFloat = innerBound < outerBound ? 0f : 1.0f - AbstractRandom.FloatAdjust;
+            float v = innerBound + nextFloat * (outerBound - innerBound);
+            if (v >= Math.Max(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int32BitsToSingle(BitConverter.SingleToInt32Bits(Math.Max(innerBound, outerBound)) - 1);
+            if (v <= Math.Min(innerBound, outerBound) && innerBound != outerBound) return BitConverter.Int32BitsToSingle(BitConverter.SingleToInt32Bits(Math.Min(innerBound, outerBound)) + 1);
+            return v;
         }
 
         /// <summary>

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -400,40 +400,40 @@ namespace ShaiRandom.Generators
         public decimal NextInclusiveDecimal(decimal innerBound, decimal outerBound) => Math.Min(innerBound, outerBound);
 
         /// <summary>
-        /// Always returns 1.0842021724855044E-19.
+        /// Always returns 1.0842021724855044E-19 (the minimum value of <see cref="AbstractRandom.NextExclusiveDouble()"/>.
         /// </summary>
         /// <returns>1.0842021724855044E-19</returns>
         public double NextExclusiveDouble() => 1.0842021724855044E-19;
 
         /// <summary>
-        /// Returns the minimum of 1.0842021724855044E-19 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// Returns the minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive).
         /// </summary>
         /// <remarks>
         /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDouble(double)"/>
-        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
-        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// in terms of how close it can get to given bounds, etc.
         /// </remarks>
         /// <param name="outerBound"/>
-        /// <returns>The minimum of 1.0842021724855044E-19 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
-        public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0.0, outerBound);
+        /// <returns>The minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
+        public double NextExclusiveDouble(double outerBound)
+        {
+            ulong value = outerBound < 0 ? ulong.MaxValue : 0;
+            return ((value >> 12) + 1L) * 2.2204460492503126E-16 * outerBound;
+        }
 
         /// <summary>
         /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
         /// </summary>
         /// <remarks>
         /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDouble(double, double)"/>
-        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
-        /// implementation which can cause it to return <paramref name="outerBound"/> or <paramref name="innerBound"/> inclusive with some values.
+        /// in terms of how close it can get to given bounds, etc.
         /// </remarks>
         /// <param name="innerBound"/>
         /// <param name="outerBound"/>
         /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
         public double NextExclusiveDouble(double innerBound, double outerBound)
         {
-            // Note: this breaks exclusivity with, for example innerBound=1.9 and outerBound=1.8 (it returns 1.8), same
-            // for innerBound=1.8 and outerBound=1.9; but the AbstractRandom implementation can as well
-            var startingVal = innerBound > outerBound ? 1.0 - AbstractRandom.DoubleAdjust : NextExclusiveDouble();
-            return innerBound + startingVal * (outerBound - innerBound);
+            ulong value = outerBound < innerBound ? ulong.MaxValue : 0;
+            return innerBound + ((value >> 12) + 1L) * 2.2204460492503126E-16 * (outerBound - innerBound);
         }
 
         /// <summary>

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -1,0 +1,280 @@
+﻿using System;
+
+namespace ShaiRandom.Generators
+{
+    /// <summary>
+    /// A "random" number generator which implements all generation functions such that they return the minimum possible
+    /// value that could be returned by an actual generator implementing the <see cref="IEnhancedRandom"/> contract.
+    /// For example, MinRandom.NextULong() always returns <see cref="ulong.MinValue"/>,
+    /// MinRandom.NextULong(1, 3) always returns 2, and so on.
+    /// </summary>
+    /// <remarks>
+    /// This generator can be useful for unit testing or debugging algorithms that use random number generators, since
+    /// bugs involving improper bounds tend to show up at either extreme of valid bounds.
+    ///
+    /// Although this generator does not inherit from <see cref="AbstractRandom"/>, it uses the same conceptual processes
+    /// for determining min and max numbers that can be returned; so in terms of how exclusive bounds are handled, this
+    /// generator performs identically to the theoretical minimums for the same values in an AbstractRandom.
+    /// </remarks>
+    public class MinRandom : IEnhancedRandom
+    {
+        /// <summary>
+        /// Static instance of this generator that can be used in most cases to prevent allocation, since this generator
+        /// has no associated state.
+        /// </summary>
+        public static readonly MinRandom Instance = new MinRandom();
+
+        /// <inheritdoc />
+        public int StateCount => 0;
+
+        /// <summary>
+        /// Doesn't support reading state, since there is no state to read.
+        /// </summary>
+        public bool SupportsReadAccess => false;
+
+        /// <summary>
+        /// Doesn't support setting state, since there is no state to set.
+        /// </summary>
+        public bool SupportsWriteAccess => false;
+
+        /// <summary>
+        /// Supports <see cref="Skip"/>.
+        /// </summary>
+        public bool SupportsSkip => true;
+
+        /// <summary>
+        /// Supports <see cref="IEnhancedRandom.PreviousULong"/>.
+        /// </summary>
+        public bool SupportsPrevious => true;
+
+        /// <summary>
+        /// Tag for this case is "MinR".
+        /// </summary>
+        public string Tag => "MinR";
+
+        static MinRandom()
+        {
+            AbstractRandom.RegisterTag(new MinRandom());
+        }
+
+        /// <summary>
+        /// Returns a new MinRandom generator; this must be equivalent to the current one, since there is no state.
+        /// </summary>
+        /// <returns>A new MinRandom generator.</returns>
+        public IEnhancedRandom Copy() => new MinRandom();
+
+        /// <inheritdoc />
+        public string StringSerialize() => $"#{Tag}``";
+
+        /// <inheritdoc />
+        public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data) => Instance;
+
+        /// <summary>
+        /// Not supported; this generator has no state.
+        /// </summary>
+        /// <param name="selection"/>
+        public ulong SelectState(int selection) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Not supported; this generator has no state.
+        /// </summary>
+        /// <param name="selection"/>
+        /// <param name="value"/>
+        public void SetSelectedState(int selection, ulong value) => throw new NotSupportedException();
+
+        /// <summary>
+        /// Does nothing, since this generator has no state.
+        /// </summary>
+        /// <param name="seed"/>
+        public void Seed(ulong seed)
+        { }
+
+        /// <summary>
+        /// Does nothing since the return value is always predetermined based on the parameters or implicit bounds.
+        /// </summary>
+        /// <param name="distance"/>
+        /// <returns><see cref="ulong.MinValue"/>.</returns>
+        public ulong Skip(ulong distance) => ulong.MinValue;
+
+        /// <summary>
+        /// Does nothing, since this generator has no state.  Always returns <see cref="ulong.MinValue"/>.
+        /// </summary>
+        /// <returns><see cref="ulong.MinValue"/></returns>
+        public ulong PreviousULong() => NextULong();
+
+        /// <summary>
+        /// Always returns <see cref="ulong.MinValue"/>.
+        /// </summary>
+        /// <returns><see cref="ulong.MinValue"/>.</returns>
+        public ulong NextULong() => ulong.MinValue;
+
+        /// <summary>
+        /// Always returns <see cref="long.MinValue"/>.
+        /// </summary>
+        /// <returns><see cref="long.MinValue"/>.</returns>
+        public long NextLong() => long.MinValue;
+
+        public ulong NextULong(ulong bound) => NextULong(0, bound);
+
+        public long NextLong(long outerBound) => NextLong(0, outerBound);
+
+        public ulong NextULong(ulong inner, ulong outer)
+        {
+            // Special case
+            if (inner == outer) return inner;
+
+            // Exclusive bound; round outer toward inner and take the minimum inclusive bound
+            return Math.Min(inner, outer - 1);
+        }
+
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outer"/> to be exclusive).
+        /// </summary>
+        /// <param name="inner"/>
+        /// <param name="outer"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outer"/> to be exclusive)</returns>
+        public long NextLong(long inner, long outer)
+        {
+            // Special case
+            if (inner == outer) return inner;
+
+            // Exclusive bound; round toward inner and take the minimum inclusive bound
+            outer = outer < inner ? outer + 1 : outer - 1;
+            return Math.Min(inner, outer);
+        }
+
+        public uint NextBits(int bits) => 0;
+
+        public void NextBytes(Span<byte> bytes)
+        {
+            for (int i = 0; i < bytes.Length; i++)
+                bytes[i] = byte.MinValue;
+        }
+
+        /// <summary>
+        /// Always returns <see cref="int.MinValue"/>.
+        /// </summary>
+        /// <returns><see cref="int.MinValue"/>.</returns>
+        public int NextInt() => int.MinValue;
+
+        public uint NextUInt() => uint.MinValue;
+
+        public uint NextUInt(uint bound) => (uint)NextULong(bound);
+
+        /// <summary>
+        /// Returns the minimum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        public int NextInt(int outerBound) => (int)NextLong(outerBound);
+
+        public uint NextUInt(uint innerBound, uint outerBound) => (uint)NextULong(innerBound, outerBound);
+
+        public int NextInt(int innerBound, int outerBound) => (int)NextLong(innerBound, outerBound);
+
+        public bool NextBool() => false;
+
+        public float NextFloat() => 0.0f;
+
+        public float NextFloat(float outerBound) => NextFloat(0, outerBound);
+
+        public float NextFloat(float innerBound, float outerBound)
+        {
+            // Note: this breaks exclusivity with, for example innerBound=1.9f and outerBound=1.8f (it returns 1.8f);
+            // but the AbstractRandom implementation can as well
+            var startingVal = innerBound > outerBound ? 1.0f - AbstractRandom.FloatAdjust : 0f;
+            return innerBound + startingVal * (outerBound - innerBound);
+        }
+
+        public double NextDouble() => 0.0;
+
+        public double NextDouble(double outerBound) => NextDouble(0, outerBound);
+
+        public double NextDouble(double innerBound, double outerBound)
+        {
+            // Note: this breaks exclusivity with, for example innerBound=1.9 and outerBound=1.8 (it returns 1.8);
+            // but the AbstractRandom implementation can as well
+            var startingVal = innerBound > outerBound ? 1.0 - AbstractRandom.DoubleAdjust : 0.0;
+            return innerBound + startingVal * (outerBound - innerBound);
+        }
+
+        public decimal NextDecimal() => 0.0M;
+
+        public decimal NextDecimal(decimal outerBound) => NextDecimal(0, outerBound);
+
+        public decimal NextDecimal(decimal innerBound, decimal outerBound)
+        {
+            unchecked
+            {
+                ulong bits = innerBound > outerBound ? 0x204fce5e3e250261UL : 0;
+                var decimalValue = new decimal((int)NextBits(28), (int)(bits & 0xFFFFFFFFUL), (int)(bits >> 32), false, 28);
+
+                return innerBound + decimalValue * (outerBound - innerBound);
+            }
+        }
+
+        public double NextInclusiveDouble() => 0.0;
+
+        public double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0.0, outerBound);
+
+        public double NextInclusiveDouble(double innerBound, double outerBound) => Math.Min(innerBound, outerBound);
+
+        public float NextInclusiveFloat() => 0.0f;
+
+        public float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0.0f, outerBound);
+
+        public float NextInclusiveFloat(float innerBound, float outerBound) => MathF.Min(innerBound, outerBound);
+
+        public decimal NextInclusiveDecimal() => 0.0M;
+
+        public decimal NextInclusiveDecimal(decimal outerBound) => NextInclusiveDecimal(0.0M, outerBound);
+
+        public decimal NextInclusiveDecimal(decimal innerBound, decimal outerBound) => Math.Min(innerBound, outerBound);
+
+        public double NextExclusiveDouble() => 1.0842021724855044E-19;
+
+        public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0.0, outerBound);
+
+        public double NextExclusiveDouble(double innerBound, double outerBound)
+        {
+            // Note: this breaks exclusivity with, for example innerBound=1.9 and outerBound=1.8 (it returns 1.8), same
+            // for innerBound=1.8 and outerBound=1.9; but the AbstractRandom implementation can as well
+            var startingVal = innerBound > outerBound ? 1.0 - AbstractRandom.DoubleAdjust : NextExclusiveDouble();
+            return innerBound + startingVal * (outerBound - innerBound);
+        }
+
+        public float NextExclusiveFloat() => 1.0842022E-19f;
+
+        public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0, outerBound);
+
+        public float NextExclusiveFloat(float innerBound, float outerBound)
+        {
+            // Note: this breaks exclusivity with, for example innerBound=1.9f and outerBound=1.8f (it returns 1.8f), same
+            // for innerBound=1.8f and outerBound=1.9f; but the AbstractRandom implementation can as well
+            var startingVal = innerBound > outerBound ? 1.0f - AbstractRandom.FloatAdjust : NextExclusiveFloat();
+            return innerBound + startingVal * (outerBound - innerBound);
+        }
+
+        public decimal NextExclusiveDecimal()
+        {
+            unchecked
+            {
+                const ulong bits = 1;
+                return new decimal(NextInt(0xFFFFFFF) + 1, (int)(bits & 0xFFFFFFFFUL), 0, false, 28);
+            }
+        }
+
+        public decimal NextExclusiveDecimal(decimal outerBound) => NextExclusiveDecimal(0.0M, outerBound);
+
+        public decimal NextExclusiveDecimal(decimal innerBound, decimal outerBound)
+        {
+            unchecked
+            {
+                ulong bits = innerBound > outerBound ? 0x204fce5e3e250261UL : 1;
+                var decimalValue = new decimal(NextInt(0xFFFFFFF) + 1, (int)(bits & 0xFFFFFFFFUL), (int)(bits >> 32), false, 28);
+
+                return innerBound + decimalValue * (outerBound - innerBound);
+            }
+        }
+    }
+}

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -114,10 +114,26 @@ namespace ShaiRandom.Generators
         /// <returns><see cref="long.MinValue"/>.</returns>
         public long NextLong() => long.MinValue;
 
+        /// <summary>
+        /// Returns the minimum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive).
+        /// </summary>
+        /// <param name="bound"/>
+        /// <returns>The minimum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive)</returns>
         public ulong NextULong(ulong bound) => NextULong(0, bound);
 
+        /// <summary>
+        /// Returns the minimum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public long NextLong(long outerBound) => NextLong(0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outer"/> to be exclusive).
+        /// </summary>
+        /// <param name="inner"/>
+        /// <param name="outer"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outer"/> to be exclusive)</returns>
         public ulong NextULong(ulong inner, ulong outer)
         {
             // Special case
@@ -143,8 +159,17 @@ namespace ShaiRandom.Generators
             return Math.Min(inner, outer);
         }
 
+        /// <summary>
+        /// Always returns 0 (no bits set).
+        /// </summary>
+        /// <param name="bits"/>
+        /// <returns>A number with no bits set (eg. 0)</returns>
         public uint NextBits(int bits) => 0;
 
+        /// <summary>
+        /// Fills the buffer with <see cref="byte.MinValue"/>.
+        /// </summary>
+        /// <param name="bytes">The buffer to fill.</param>
         public void NextBytes(Span<byte> bytes)
         {
             for (int i = 0; i < bytes.Length; i++)
@@ -157,8 +182,17 @@ namespace ShaiRandom.Generators
         /// <returns><see cref="int.MinValue"/>.</returns>
         public int NextInt() => int.MinValue;
 
+        /// <summary>
+        /// Always returns <see cref="uint.MinValue"/>.
+        /// </summary>
+        /// <returns><see cref="uint.MinValue"/>.</returns>
         public uint NextUInt() => uint.MinValue;
 
+        /// <summary>
+        /// Returns the minimum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive).
+        /// </summary>
+        /// <param name="bound"/>
+        /// <returns>The minimum of 0 and the defined bound (considering <paramref name="bound"/> to be exclusive)</returns>
         public uint NextUInt(uint bound) => (uint)NextULong(bound);
 
         /// <summary>
@@ -168,16 +202,57 @@ namespace ShaiRandom.Generators
         /// <returns>The minimum of 0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public int NextInt(int outerBound) => (int)NextLong(outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public uint NextUInt(uint innerBound, uint outerBound) => (uint)NextULong(innerBound, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public int NextInt(int innerBound, int outerBound) => (int)NextLong(innerBound, outerBound);
 
+        /// <summary>
+        /// Always returns false.
+        /// </summary>
+        /// <returns>False</returns>
         public bool NextBool() => false;
 
+        /// <summary>
+        /// Always returns 0.0f.
+        /// </summary>
+        /// <returns>0.0f</returns>
         public float NextFloat() => 0.0f;
 
+        /// <summary>
+        /// Returns the minimum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextFloat(float outerBound) => NextFloat(0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextFloat(float, float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextFloat(float innerBound, float outerBound)
         {
             // Note: this breaks exclusivity with, for example innerBound=1.9f and outerBound=1.8f (it returns 1.8f);
@@ -186,10 +261,35 @@ namespace ShaiRandom.Generators
             return innerBound + startingVal * (outerBound - innerBound);
         }
 
+        /// <summary>
+        /// Always returns 0.0.
+        /// </summary>
+        /// <returns>0.0</returns>
         public double NextDouble() => 0.0;
 
+        /// <summary>
+        /// Returns the minimum of 0.0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDouble(double)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public double NextDouble(double outerBound) => NextDouble(0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDouble(double, double)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public double NextDouble(double innerBound, double outerBound)
         {
             // Note: this breaks exclusivity with, for example innerBound=1.9 and outerBound=1.8 (it returns 1.8);
@@ -198,10 +298,33 @@ namespace ShaiRandom.Generators
             return innerBound + startingVal * (outerBound - innerBound);
         }
 
+        /// <summary>
+        /// Always returns 0.0M.
+        /// </summary>
+        /// <returns>0.0M</returns>
         public decimal NextDecimal() => 0.0M;
 
+        /// <summary>
+        /// Returns the minimum of 0.0M and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDecimal(decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0M and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public decimal NextDecimal(decimal outerBound) => NextDecimal(0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextDecimal(decimal, decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public decimal NextDecimal(decimal innerBound, decimal outerBound)
         {
             unchecked
@@ -213,28 +336,98 @@ namespace ShaiRandom.Generators
             }
         }
 
+        /// <summary>
+        /// Always returns 0.0.
+        /// </summary>
+        /// <returns>0.0</returns>
         public double NextInclusiveDouble() => 0.0;
 
+        /// <summary>
+        /// Returns the minimum of 0.0 and the defined bound.
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0 and the defined bound</returns>
         public double NextInclusiveDouble(double outerBound) => NextInclusiveDouble(0.0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds.
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds</returns>
         public double NextInclusiveDouble(double innerBound, double outerBound) => Math.Min(innerBound, outerBound);
 
+        /// <summary>
+        /// Always returns 0.0f.
+        /// </summary>
+        /// <returns>0.0f</returns>
         public float NextInclusiveFloat() => 0.0f;
 
+        /// <summary>
+        /// Returns the minimum of 0.0f and the defined bound.
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0f and the defined bound</returns>
         public float NextInclusiveFloat(float outerBound) => NextInclusiveFloat(0.0f, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds.
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds</returns>
         public float NextInclusiveFloat(float innerBound, float outerBound) => MathF.Min(innerBound, outerBound);
 
+        /// <summary>
+        /// Always returns 0.0M.
+        /// </summary>
+        /// <returns>0.0M</returns>
         public decimal NextInclusiveDecimal() => 0.0M;
 
+        /// <summary>
+        /// Returns the minimum of 0.0M and the defined bound.
+        /// </summary>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0M and the defined bound</returns>
         public decimal NextInclusiveDecimal(decimal outerBound) => NextInclusiveDecimal(0.0M, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds.
+        /// </summary>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds</returns>
         public decimal NextInclusiveDecimal(decimal innerBound, decimal outerBound) => Math.Min(innerBound, outerBound);
 
+        /// <summary>
+        /// Always returns 1.0842021724855044E-19.
+        /// </summary>
+        /// <returns>1.0842021724855044E-19</returns>
         public double NextExclusiveDouble() => 1.0842021724855044E-19;
 
+        /// <summary>
+        /// Returns the minimum of 1.0842021724855044E-19 and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDouble(double)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 1.0842021724855044E-19 and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public double NextExclusiveDouble(double outerBound) => NextExclusiveDouble(0.0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDouble(double, double)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> or <paramref name="innerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
         public double NextExclusiveDouble(double innerBound, double outerBound)
         {
             // Note: this breaks exclusivity with, for example innerBound=1.9 and outerBound=1.8 (it returns 1.8), same
@@ -243,10 +436,35 @@ namespace ShaiRandom.Generators
             return innerBound + startingVal * (outerBound - innerBound);
         }
 
+        /// <summary>
+        /// Always returns 1.0842022E-19f.
+        /// </summary>
+        /// <returns>1.0842022E-19f</returns>
         public float NextExclusiveFloat() => 1.0842022E-19f;
 
+        /// <summary>
+        /// Returns the minimum of 1.0842022E-19f and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveFloat(float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 1.0842022E-19f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveFloat(float, float)"/>
+        /// in terms of how close it can get to given bounds, etc.  Currently, it also shares issues with the AbstractRandom
+        /// implementation which can cause it to return <paramref name="outerBound"/> or <paramref name="innerBound"/> inclusive with some values.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
         public float NextExclusiveFloat(float innerBound, float outerBound)
         {
             // Note: this breaks exclusivity with, for example innerBound=1.9f and outerBound=1.8f (it returns 1.8f), same
@@ -255,23 +473,39 @@ namespace ShaiRandom.Generators
             return innerBound + startingVal * (outerBound - innerBound);
         }
 
-        public decimal NextExclusiveDecimal()
-        {
-            unchecked
-            {
-                const ulong bits = 1;
-                return new decimal(NextInt(0xFFFFFFF) + 1, (int)(bits & 0xFFFFFFFFUL), 0, false, 28);
-            }
-        }
+        /// <summary>
+        /// Always returns 0.0000000000000000000000000001M.
+        /// </summary>
+        /// <returns>0.0000000000000000000000000001M</returns>
+        public decimal NextExclusiveDecimal() => new decimal(1, 0, 0, false, 28);
 
+        /// <summary>
+        /// Returns the minimum of 0.0000000000000000000000000001M and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDecimal(decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of 0.0000000000000000000000000001M and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
         public decimal NextExclusiveDecimal(decimal outerBound) => NextExclusiveDecimal(0.0M, outerBound);
 
+        /// <summary>
+        /// Returns the minimum of the defined bounds (considering both bounds to be exclusive).
+        /// </summary>
+        /// <remarks>
+        /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDecimal(decimal, decimal)"/>
+        /// in terms of how close it can get to given bounds, etc.
+        /// </remarks>
+        /// <param name="innerBound"/>
+        /// <param name="outerBound"/>
+        /// <returns>The minimum of the defined bounds (considering both bounds to be exclusive)</returns>
         public decimal NextExclusiveDecimal(decimal innerBound, decimal outerBound)
         {
             unchecked
             {
-                ulong bits = innerBound > outerBound ? 0x204fce5e3e250261UL : 1;
-                var decimalValue = new decimal(NextInt(0xFFFFFFF) + 1, (int)(bits & 0xFFFFFFFFUL), (int)(bits >> 32), false, 28);
+                ulong bits = innerBound > outerBound ? 0x204fce5e3e250261UL : 0;
+                var decimalValue = new decimal(1, (int)(bits & 0xFFFFFFFFUL), (int)(bits >> 32), false, 28);
 
                 return innerBound + decimalValue * (outerBound - innerBound);
             }

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -6,7 +6,7 @@ namespace ShaiRandom.Generators
     /// A "random" number generator which implements all generation functions such that they return the minimum possible
     /// value that could be returned by an actual generator implementing the <see cref="IEnhancedRandom"/> contract.
     /// For example, MinRandom.NextULong() always returns <see cref="ulong.MinValue"/>,
-    /// MinRandom.NextULong(1, 3) always returns 2, and so on.
+    /// MinRandom.NextULong(1, 3) always returns 1, and so on.
     /// </summary>
     /// <remarks>
     /// This generator can be useful for unit testing or debugging algorithms that use random number generators, since
@@ -94,7 +94,7 @@ namespace ShaiRandom.Generators
         /// </summary>
         /// <param name="distance"/>
         /// <returns><see cref="ulong.MinValue"/>.</returns>
-        public ulong Skip(ulong distance) => ulong.MinValue;
+        public ulong Skip(ulong distance) => NextULong();
 
         /// <summary>
         /// Does nothing, since this generator has no state.  Always returns <see cref="ulong.MinValue"/>.

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -444,7 +444,7 @@ namespace ShaiRandom.Generators
         public float NextExclusiveFloat() => 1.0842022E-19f;
 
         /// <summary>
-        /// Returns the minimum of 1.0842022E-19f and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// Returns the minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive).
         /// </summary>
         /// <remarks>
         /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveFloat(float)"/>
@@ -452,7 +452,7 @@ namespace ShaiRandom.Generators
         /// implementation which can cause it to return <paramref name="outerBound"/> inclusive with some values.
         /// </remarks>
         /// <param name="outerBound"/>
-        /// <returns>The minimum of 1.0842022E-19f and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        /// <returns>The minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
         public float NextExclusiveFloat(float outerBound) => NextExclusiveFloat(0f, outerBound);
 
         /// <summary>
@@ -483,14 +483,14 @@ namespace ShaiRandom.Generators
         public decimal NextExclusiveDecimal() => new decimal(1, 0, 0, false, 28);
 
         /// <summary>
-        /// Returns the minimum of 0.0000000000000000000000000001M and the defined bound (considering <paramref name="outerBound"/> to be exclusive).
+        /// Returns the minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive).
         /// </summary>
         /// <remarks>
         /// In general, this function has the same characteristics of <see cref="AbstractRandom.NextExclusiveDecimal(decimal)"/>
         /// in terms of how close it can get to given bounds, etc.
         /// </remarks>
         /// <param name="outerBound"/>
-        /// <returns>The minimum of 0.0000000000000000000000000001M and the defined bound (considering <paramref name="outerBound"/> to be exclusive)</returns>
+        /// <returns>The minimum of 0 and the defined bound (considering both 0 and <paramref name="outerBound"/> to be exclusive)</returns>
         public decimal NextExclusiveDecimal(decimal outerBound) => NextExclusiveDecimal(0.0M, outerBound);
 
         /// <summary>


### PR DESCRIPTION
# Changes
- Made `s_floatAdjust` and `s_doubleAdjust` values public, and renamed them accordingly
- Implemented `MinRandom`; a generator where the number generation functions always returns the minimum legal value according to the contract for the function
    - Fails unit tests; see notes
- Implemented `MaxRandom`; same as `MinRandom`, but returns the maximum legal value instead.
    - Also fails unit tests; see notes
- Added capability to unit test framework to exclude certain generators from distribution checks
    - Necessary to test generators like MinRandom/MaxRandom, since clearly they do not uniformly distribute
- Augmented error messages for `KnownSeriesRandom` to specify the illegal value in the message when exceptions are thrown
- Modified `AbstractRandom` implementations of `StringSerialize` and `StringDeserialize` to handle generators with 0 states without crashing
    - Such generators need not support read or write access, since the implementation will now ensure it never attempts to write any states if no states exist
- Miscellanous code cleanup

# Goals/End-State
The ultimate goal of this PR was simply to implement the `MinRandom` and `MaxRandom` concept from GoRogue (described above), as generators in ShaiRandom.  Unfortunately, this proved more complex than anticipated.

First, the generators do not inherit from `AbstractRandom`, since in many cases (particularly floating-point functions) they can't use the predefined methods of generating values.  Nonetheless, they do try to adhere to the algorithms used in `AbstractRandom` where possible.  This, in theory, serves two purposes:
1. It helps to mathematically validate the extent of bounds as enforced by the `AbstractRandom` algorithms
2. It ensures that `MinRandom` and `MaxRandom` replicate the realistic bounds of common generators as closely as possible.

The primary issue that remains, is 21 unit tests (10 MinRandom, and 11 MaxRandom) are currently failing.  As it turns out, this appears to be due to actual cases where the theoretical bounds for floating point functions, as implemented by `AbstractRandom`, exceed the bounds allowed by the `IEnhancedRandom` contract.

If you happen to see any that are failing due to implementation issues with `MinRandom`/`MaxRandom`, feel free to comment on them and I'll get it fixed up as soon as possible.  Otherwise, I figured these implementations combined with the unit tests might actually be helpful during the process of fixing the bounds issues; so I wanted to submit them in a PR even though they are failing some of the bounds-based unit tests.

There are also a few miscellaneous code-cleanup type changes in here, mostly to the effect of fixing warnings pertaining to nullable reference types in performance tests.