### PR TITLE
Refactored/Fixed Serialization

### DIFF
--- a/ShaiRandom.UnitTests/Scratch.cs
+++ b/ShaiRandom.UnitTests/Scratch.cs
@@ -206,7 +206,7 @@ namespace ShaiRandom.UnitTests
                 {
                     if(forward[i] != gen.PreviousULong())
                     {
-                        Console.WriteLine(gen.Tag + " on " + i);
+                        Console.WriteLine(gen.DefaultTag + " on " + i);
                     }
                 }
             }

--- a/ShaiRandom.UnitTests/SerializationTests.cs
+++ b/ShaiRandom.UnitTests/SerializationTests.cs
@@ -41,12 +41,12 @@ namespace ShaiRandom.UnitTests
             gen.NextULong();
 
             // Serialize generator
-            string ser = gen.StringSerialize();
+            string ser = Serializer.Serialize(gen);
             Assert.StartsWith(gen.Tag, ser);
             Assert.EndsWith("`", ser);
 
             // Deserialize generator
-            var gen2 = AbstractRandom.Deserialize(ser);
+            var gen2 = Serializer.Deserialize(ser);
 
             // Check that its state is equivalent and it generates identical numbers
             Assert.True(gen.Matches(gen2));
@@ -68,7 +68,7 @@ namespace ShaiRandom.UnitTests
             Assert.EndsWith("`", ser);
 
             // Deserialize generator
-            var ksr2 = (KnownSeriesRandom)AbstractRandom.Deserialize(ser);
+            var ksr2 = (KnownSeriesRandom)Serializer.Deserialize(ser);
             // Check that its state (indices) are equivalent to the original
             Assert.True(ksr.Matches(ksr2));
             // Check that each list is identical

--- a/ShaiRandom.UnitTests/SerializationTests.cs
+++ b/ShaiRandom.UnitTests/SerializationTests.cs
@@ -42,7 +42,7 @@ namespace ShaiRandom.UnitTests
 
             // Serialize generator
             string ser = Serializer.Serialize(gen);
-            Assert.StartsWith(gen.Tag, ser);
+            Assert.StartsWith(Serializer.GetTag(gen), ser);
             Assert.EndsWith("`", ser);
 
             // Deserialize generator
@@ -64,7 +64,7 @@ namespace ShaiRandom.UnitTests
 
             // Serialize generator
             string ser = ksr.StringSerialize();
-            Assert.StartsWith(ksr.Tag, ser);
+            Assert.StartsWith(Serializer.GetTag(ksr), ser);
             Assert.EndsWith("`", ser);
 
             // Deserialize generator

--- a/ShaiRandom.UnitTests/TestFramework.cs
+++ b/ShaiRandom.UnitTests/TestFramework.cs
@@ -1,0 +1,15 @@
+﻿using Xunit.Abstractions;
+using Xunit.Sdk;
+
+[assembly: Xunit.TestFramework("ShaiRandom.UnitTests.TestFramework", "ShaiRandom.UnitTests")]
+namespace ShaiRandom.UnitTests
+{
+    public class TestFramework : XunitTestFramework
+    {
+        public TestFramework(IMessageSink messageSink)
+            :base(messageSink)
+        {
+            Serializer.RegisterShaiRandomDefaultTags();
+        }
+    }
+}

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Text;
-using ShaiRandom.Wrappers;
 
 namespace ShaiRandom.Generators
 {
@@ -64,25 +62,6 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public abstract string Tag { get; }
 
-        private static Dictionary<string, IEnhancedRandom> TAGS = new Dictionary<string, IEnhancedRandom>();
-
-        /// <summary>
-        /// Registers an instance of an IEnhancedRandom implementation by its four-character string <see cref="Tag"/>.
-        /// </summary>
-        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
-        /// as long as it is non-null and has a four-character <see cref="Tag"/>.</param>
-        /// <returns>Returns true if the tag was successfully registered for the first time, or false if the tags are unchanged.</returns>
-        public static bool RegisterTag(IEnhancedRandom instance)
-        {
-            if (TAGS.ContainsKey(instance.Tag)) return false;
-            if (instance.Tag.Length != 0)
-            {
-                TAGS.Add(instance.Tag, instance);
-                return true;
-            }
-            return false;
-        }
-
 
         /// <inheritdoc />
         public virtual string StringSerialize()
@@ -119,30 +98,6 @@ namespace ShaiRandom.Generators
             }
 
             return this;
-        }
-
-        /// <summary>
-        /// Given data from a string produced by <see cref="StringSerialize()"/> on any valid IEnhancedRandom,
-        /// this returns a new IEnhancedRandom with the same implementation and state it had when it was serialized.
-        /// </summary>
-        /// <remarks>
-        /// This handles all IEnhancedRandom implementations in this library, including <see cref="TRGeneratorWrapper"/>,
-        /// <see cref="ReversingWrapper"/>, and <see cref="ArchivalWrapper"/> (all of which it currently handles with a special case).
-        /// This takes a ReadOnlySpan of char, which allows data to be any string or some more specialized types.
-        /// </remarks>
-        /// <param name="data">A string or ReadOnlySpan of char produced by an IEnhancedRandom's StringSerialize() method.</param>
-        /// <returns>A newly-allocated IEnhancedRandom matching the implementation and state of the serialized AbstractRandom.</returns>
-        public static IEnhancedRandom Deserialize(ReadOnlySpan<char> data)
-        {
-            int idx = data.IndexOf('`');
-            if (idx == -1)
-                throw new ArgumentException("String given cannot represent a valid generator.");
-
-            // Can't use Span as the key in a dictionary, so we have to allocate a string to perform the lookup.
-            // When the feature linked here is implemented, we could get around this:
-            // https://github.com/dotnet/runtime/issues/27229
-            string tagData = new string(data[..idx]);
-            return TAGS[tagData].Copy().StringDeserialize(data[idx..]);
         }
 
         /// <inheritdoc />

--- a/ShaiRandom/Generators/AbstractRandom.cs
+++ b/ShaiRandom/Generators/AbstractRandom.cs
@@ -60,13 +60,13 @@ namespace ShaiRandom.Generators
         public abstract bool SupportsPrevious { get; }
 
         /// <inheritdoc />
-        public abstract string Tag { get; }
+        public abstract string DefaultTag { get; }
 
 
         /// <inheritdoc />
         public virtual string StringSerialize()
         {
-            var ser = new StringBuilder(Tag);
+            var ser = new StringBuilder(Serializer.GetTag(this));
             ser.Append('`');
             if (StateCount > 0)
             {

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -20,7 +20,7 @@ namespace ShaiRandom.Generators
         public override string Tag => "DisR";
         static DistinctRandom()
         {
-            RegisterTag(new DistinctRandom(1UL));
+            Serializer.RegisterTag(new DistinctRandom(1UL));
         }
 
         /// <summary>

--- a/ShaiRandom/Generators/DistinctRandom.cs
+++ b/ShaiRandom/Generators/DistinctRandom.cs
@@ -17,11 +17,7 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "DisR" .
         /// </summary>
-        public override string Tag => "DisR";
-        static DistinctRandom()
-        {
-            Serializer.RegisterTag(new DistinctRandom(1UL));
-        }
+        public override string DefaultTag => "DisR";
 
         /// <summary>
         /// The first state; can be any ulong.

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -18,7 +18,7 @@ namespace ShaiRandom.Generators
 
         static FourWheelRandom()
         {
-            RegisterTag(new FourWheelRandom(1UL, 1UL, 1UL, 1UL));
+            Serializer.RegisterTag(new FourWheelRandom(1UL, 1UL, 1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong.

--- a/ShaiRandom/Generators/FourWheelRandom.cs
+++ b/ShaiRandom/Generators/FourWheelRandom.cs
@@ -14,12 +14,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "FoWR" .
         /// </summary>
-        public override string Tag => "FoWR";
-
-        static FourWheelRandom()
-        {
-            Serializer.RegisterTag(new FourWheelRandom(1UL, 1UL, 1UL, 1UL));
-        }
+        public override string DefaultTag => "FoWR";
+        
         /// <summary>
         /// The first state; can be any ulong.
         /// </summary>

--- a/ShaiRandom/Generators/IEnhancedRandom.cs
+++ b/ShaiRandom/Generators/IEnhancedRandom.cs
@@ -48,14 +48,10 @@ namespace ShaiRandom.Generators
         bool SupportsPrevious { get; }
 
         /// <summary>
-        /// The exactly-four-character string that may identify this IEnhancedRandom for serialization purposes.
+        /// The string that may identify this IEnhancedRandom for serialization purposes, if no specific string is specified
+        /// when the generator is registered with the serializer.
         /// </summary>
-        /// <remarks>
-        /// If this is not four characters in length, it will be ignored, and this IEnhancedRandom will not be serializable by the mechanisms here.
-        /// Wrapper classes that contain an IEnhancedRandom and alter some properties of it will often use a one-character tag, which is intentionally invalid
-        /// because they cannot be serialized without the IEnhancedRandom they contain.
-        /// </remarks>
-        string Tag { get; }
+        string DefaultTag { get; }
 
         /// <summary>
         /// Returns a full copy (deep, if necessary) of this IEnhancedRandom.

--- a/ShaiRandom/Generators/IEnhancedRandom.cs
+++ b/ShaiRandom/Generators/IEnhancedRandom.cs
@@ -76,7 +76,7 @@ namespace ShaiRandom.Generators
         /// This is an optional operation for classes that only implement IEnhancedRandom; AbstractRandom strongly encourages but does not require an implementation.
         /// </summary>
         /// <remarks>
-        /// It is more common to call <see cref="AbstractRandom.Deserialize(ReadOnlySpan{char})"/> when the exact variety of IEnhancedRandom is not known.
+        /// It is more common to call <see cref="Serializer.Deserialize(ReadOnlySpan{char})"/> when the exact variety of IEnhancedRandom is not known.
         /// </remarks>
         /// <param name="data">Data from a string produced by StringSerialize.</param>
         /// <returns>This IEnhancedRandom, after modifications.</returns>

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -167,11 +167,7 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "KnSR" .
         /// </summary>
-        public string Tag => "KnSR";
-        static KnownSeriesRandom()
-        {
-            Serializer.RegisterTag(new KnownSeriesRandom());
-        }
+        public string DefaultTag => "KnSR";
 
         private static T ReturnIfBetweenBounds<T>(T innerValue, T outerValue, List<T> series, ref int seriesIndex)
             where T : IComparable<T>
@@ -833,7 +829,9 @@ namespace ShaiRandom.Generators
         /// <inheritdoc />
         public string StringSerialize()
         {
-            StringBuilder ser = new StringBuilder("KnSR`");
+
+            StringBuilder ser = new StringBuilder(Serializer.GetTag(this));
+            ser.Append('`');
             ser.Append(_intIndex); ser.Append('~');
             SerializeList(ser, _intSeries);
             ser.Append(_uintIndex); ser.Append('~');

--- a/ShaiRandom/Generators/KnownSeriesRandom.cs
+++ b/ShaiRandom/Generators/KnownSeriesRandom.cs
@@ -170,7 +170,7 @@ namespace ShaiRandom.Generators
         public string Tag => "KnSR";
         static KnownSeriesRandom()
         {
-            AbstractRandom.RegisterTag(new KnownSeriesRandom());
+            Serializer.RegisterTag(new KnownSeriesRandom());
         }
 
         private static T ReturnIfBetweenBounds<T>(T innerValue, T outerValue, List<T> series, ref int seriesIndex)

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -10,12 +10,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "LasR" .
         /// </summary>
-        public override string Tag => "LasR";
-
-        static LaserRandom()
-        {
-            Serializer.RegisterTag(new LaserRandom(1UL, 1UL));
-        }
+        public override string DefaultTag => "LasR";
+        
         /// <summary>
         /// The first state; can be any ulong.
         /// </summary>

--- a/ShaiRandom/Generators/LaserRandom.cs
+++ b/ShaiRandom/Generators/LaserRandom.cs
@@ -14,7 +14,7 @@ namespace ShaiRandom.Generators
 
         static LaserRandom()
         {
-            RegisterTag(new LaserRandom(1UL, 1UL));
+            Serializer.RegisterTag(new LaserRandom(1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong.

--- a/ShaiRandom/Generators/MaxRandom.cs
+++ b/ShaiRandom/Generators/MaxRandom.cs
@@ -55,7 +55,7 @@ namespace ShaiRandom.Generators
 
         static MaxRandom()
         {
-            AbstractRandom.RegisterTag(new MaxRandom());
+            Serializer.RegisterTag(new MaxRandom());
         }
 
         /// <summary>

--- a/ShaiRandom/Generators/MaxRandom.cs
+++ b/ShaiRandom/Generators/MaxRandom.cs
@@ -51,12 +51,7 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// Tag for this case is "MinR".
         /// </summary>
-        public string Tag => "MaxR";
-
-        static MaxRandom()
-        {
-            Serializer.RegisterTag(new MaxRandom());
-        }
+        public string DefaultTag => "MaxR";
 
         /// <summary>
         /// Returns a new MinRandom generator; this must be equivalent to the current one, since there is no state.
@@ -65,7 +60,7 @@ namespace ShaiRandom.Generators
         public IEnhancedRandom Copy() => new MaxRandom();
 
         /// <inheritdoc />
-        public string StringSerialize() => $"{Tag}``";
+        public string StringSerialize() => $"{Serializer.GetTag(this)}``";
 
         /// <inheritdoc />
         public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data) => Instance;

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -55,7 +55,7 @@ namespace ShaiRandom.Generators
 
         static MinRandom()
         {
-            AbstractRandom.RegisterTag(new MinRandom());
+            Serializer.RegisterTag(new MinRandom());
         }
 
         /// <summary>

--- a/ShaiRandom/Generators/MinRandom.cs
+++ b/ShaiRandom/Generators/MinRandom.cs
@@ -51,12 +51,7 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// Tag for this case is "MinR".
         /// </summary>
-        public string Tag => "MinR";
-
-        static MinRandom()
-        {
-            Serializer.RegisterTag(new MinRandom());
-        }
+        public string DefaultTag => "MinR";
 
         /// <summary>
         /// Returns a new MinRandom generator; this must be equivalent to the current one, since there is no state.
@@ -65,7 +60,7 @@ namespace ShaiRandom.Generators
         public IEnhancedRandom Copy() => new MinRandom();
 
         /// <inheritdoc />
-        public string StringSerialize() => $"{Tag}``";
+        public string StringSerialize() => $"{Serializer.GetTag(this)}``";
 
         /// <inheritdoc />
         public IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data) => Instance;

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -15,12 +15,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "MizR" .
         /// </summary>
-        public override string Tag => "MizR";
-
-        static MizuchiRandom()
-        {
-            Serializer.RegisterTag(new MizuchiRandom(1UL, 1UL));
-        }
+        public override string DefaultTag => "MizR";
+        
         /// <summary>
         /// The first state; can be any ulong.
         /// </summary>

--- a/ShaiRandom/Generators/MizuchiRandom.cs
+++ b/ShaiRandom/Generators/MizuchiRandom.cs
@@ -19,7 +19,7 @@ namespace ShaiRandom.Generators
 
         static MizuchiRandom()
         {
-            RegisterTag(new MizuchiRandom(1UL, 1UL));
+            Serializer.RegisterTag(new MizuchiRandom(1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong.

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -30,12 +30,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "RTrR" .
         /// </summary>
-        public override string Tag => "RTrR";
+        public override string DefaultTag => "RTrR";
 
-        static RomuTrioRandom()
-        {
-            Serializer.RegisterTag(new RomuTrioRandom(1UL, 1UL, 1UL));
-        }
         /// <summary>
         /// The first state; can be any ulong except that the whole state must not all be 0.
         /// </summary>

--- a/ShaiRandom/Generators/RomuTrioRandom.cs
+++ b/ShaiRandom/Generators/RomuTrioRandom.cs
@@ -34,7 +34,7 @@ namespace ShaiRandom.Generators
 
         static RomuTrioRandom()
         {
-            RegisterTag(new RomuTrioRandom(1UL, 1UL, 1UL));
+            Serializer.RegisterTag(new RomuTrioRandom(1UL, 1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong except that the whole state must not all be 0.

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -14,7 +14,7 @@ namespace ShaiRandom.Generators
 
         static StrangerRandom()
         {
-            RegisterTag(new StrangerRandom(1UL, 1UL, 1UL, 1UL));
+            Serializer.RegisterTag(new StrangerRandom(1UL, 1UL, 1UL, 1UL));
         }
         private ulong _a, _b;
         /// <summary>

--- a/ShaiRandom/Generators/StrangerRandom.cs
+++ b/ShaiRandom/Generators/StrangerRandom.cs
@@ -10,12 +10,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "StrR" .
         /// </summary>
-        public override string Tag => "StrR";
+        public override string DefaultTag => "StrR";
 
-        static StrangerRandom()
-        {
-            Serializer.RegisterTag(new StrangerRandom(1UL, 1UL, 1UL, 1UL));
-        }
         private ulong _a, _b;
         /// <summary>
         /// The first state; can be any ulong except 0.

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -10,12 +10,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "TriR" .
         /// </summary>
-        public override string Tag => "TriR";
+        public override string DefaultTag => "TriR";
 
-        static TricycleRandom()
-        {
-            Serializer.RegisterTag(new TricycleRandom(1UL, 1UL, 1UL));
-        }
         /// <summary>
         /// The first state; can be any ulong.
         /// </summary>

--- a/ShaiRandom/Generators/TricycleRandom.cs
+++ b/ShaiRandom/Generators/TricycleRandom.cs
@@ -14,7 +14,7 @@ namespace ShaiRandom.Generators
 
         static TricycleRandom()
         {
-            RegisterTag(new TricycleRandom(1UL, 1UL, 1UL));
+            Serializer.RegisterTag(new TricycleRandom(1UL, 1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong.

--- a/ShaiRandom/Generators/TrimRandom.cs
+++ b/ShaiRandom/Generators/TrimRandom.cs
@@ -17,12 +17,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "TrmR" .
         /// </summary>
-        public override string Tag => "TrmR";
+        public override string DefaultTag => "TrmR";
 
-        static TrimRandom()
-        {
-            Serializer.RegisterTag(new TrimRandom(1UL, 1UL, 1UL, 1UL));
-        }
         /// <summary>
         /// The first state; can be any ulong.
         /// </summary>

--- a/ShaiRandom/Generators/TrimRandom.cs
+++ b/ShaiRandom/Generators/TrimRandom.cs
@@ -21,7 +21,7 @@ namespace ShaiRandom.Generators
 
         static TrimRandom()
         {
-            RegisterTag(new TrimRandom(1UL, 1UL, 1UL, 1UL));
+            Serializer.RegisterTag(new TrimRandom(1UL, 1UL, 1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong.

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -16,12 +16,8 @@ namespace ShaiRandom.Generators
         /// <summary>
         /// The identifying tag here is "XSSR" .
         /// </summary>
-        public override string Tag => "XSSR";
+        public override string DefaultTag => "XSSR";
 
-        static Xoshiro256StarStarRandom()
-        {
-            Serializer.RegisterTag(new Xoshiro256StarStarRandom(1UL, 1UL, 1UL, 1UL));
-        }
         /// <summary>
         /// The first state; can be any ulong except that the whole state must not all be 0.
         /// </summary>

--- a/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
+++ b/ShaiRandom/Generators/Xoshiro256StarStarRandom.cs
@@ -20,7 +20,7 @@ namespace ShaiRandom.Generators
 
         static Xoshiro256StarStarRandom()
         {
-            RegisterTag(new Xoshiro256StarStarRandom(1UL, 1UL, 1UL, 1UL));
+            Serializer.RegisterTag(new Xoshiro256StarStarRandom(1UL, 1UL, 1UL, 1UL));
         }
         /// <summary>
         /// The first state; can be any ulong except that the whole state must not all be 0.

--- a/ShaiRandom/Serializer.cs
+++ b/ShaiRandom/Serializer.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using ShaiRandom.Generators;
+using ShaiRandom.Wrappers;
+
+namespace ShaiRandom
+{
+    /// <summary>
+    /// Static class containing deserialization logic to take a string produced by <see cref="IEnhancedRandom.StringDeserialize"/>
+    /// and produce an appropriate generator.
+    /// </summary>
+    /// <remarks>
+    /// If you have custom <see cref="IEnhancedRandom"/> implementations, provided they implement <see cref="IEnhancedRandom.StringSerialize"/>,
+    /// <see cref="IEnhancedRandom.StringDeserialize"/>, and <see cref="IEnhancedRandom.Copy"/>, you may register them to function with this
+    /// serializer by calling <see cref="RegisterTag"/>.
+    ///
+    /// This only needs to be done once per type, and is typically performed inside a static class constructor for your RNG type.  The generator
+    /// implementations in ShaiRandom do this same thing; feel free to look at any of them for an example.
+    /// </remarks>
+    public static class Serializer
+    {
+        private static readonly Dictionary<string, IEnhancedRandom> s_tags = new Dictionary<string, IEnhancedRandom>();
+
+        /// <summary>
+        /// List of tags registered to the serializer.  Register a type to its tag with <see cref="RegisterTag"/>.
+        /// </summary>
+        public static IReadOnlyDictionary<string, IEnhancedRandom> Tags => s_tags;
+
+        /// <summary>
+        /// Registers an instance of an IEnhancedRandom implementation by its string <see cref="IEnhancedRandom.Tag"/>.
+        /// </summary>
+        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
+        /// as long as it is non-null and has a four-character <see cref="IEnhancedRandom.Tag"/>.</param>
+        /// <returns>Returns true if the tag was successfully registered for the first time, or false if the tags are unchanged.</returns>
+        public static bool RegisterTag(IEnhancedRandom instance)
+        {
+            if (s_tags.ContainsKey(instance.Tag)) return false;
+            if (instance.Tag.Length != 0)
+            {
+                s_tags.Add(instance.Tag, instance);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Produces a string representing the serialized form of the given RNG, by calling its <see cref="IEnhancedRandom.StringSerialize"/>
+        /// method.
+        /// </summary>
+        /// <param name="rng">RNG to serialize.</param>
+        /// <returns>A string representing the serialized form of the given RNG.</returns>
+        public static string Serialize(IEnhancedRandom rng) => rng.StringSerialize();
+
+        /// <summary>
+        /// Given data from a string produced by <see cref="IEnhancedRandom.StringSerialize"/> on any registered IEnhancedRandom,
+        /// this returns a new IEnhancedRandom with the same implementation and state it had when it was serialized.
+        /// </summary>
+        /// <remarks>
+        /// This handles all IEnhancedRandom implementations in this library, including <see cref="TRGeneratorWrapper"/>,
+        /// <see cref="ReversingWrapper"/>, and <see cref="ArchivalWrapper"/>.  It will also work with arbitrary custom
+        /// IEnhancedRandom implementations, provided they implement StringSerialize, StringDeserialize, and Copy, and register
+        /// their tag via <see cref="RegisterTag"/>.
+        ///
+        /// This function takes as input a ReadOnlySpan of char, which allows data to be any string or some more specialized types.
+        /// </remarks>
+        /// <param name="data">A string or ReadOnlySpan of char produced by an IEnhancedRandom's StringSerialize() method.</param>
+        /// <returns>A newly-allocated IEnhancedRandom matching the implementation and state of the serialized IEnhancedRandom.</returns>
+        public static IEnhancedRandom Deserialize(ReadOnlySpan<char> data)
+        {
+            int idx = data.IndexOf('`');
+            if (idx == -1)
+                throw new ArgumentException("String given cannot represent a valid generator.");
+
+            // Can't use Span as the key in a dictionary, so we have to allocate a string to perform the lookup.
+            // When the feature linked here is implemented, we could get around this:
+            // https://github.com/dotnet/runtime/issues/27229
+            string tagData = new string(data[..idx]);
+            return s_tags[tagData].Copy().StringDeserialize(data[idx..]);
+        }
+    }
+}

--- a/ShaiRandom/Serializer.cs
+++ b/ShaiRandom/Serializer.cs
@@ -1,48 +1,326 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using ShaiRandom.Generators;
 using ShaiRandom.Wrappers;
 
 namespace ShaiRandom
 {
     /// <summary>
-    /// Static class containing deserialization logic to take a string produced by <see cref="IEnhancedRandom.StringDeserialize"/>
+    /// Static class containing logic to take a string produced by <see cref="IEnhancedRandom.StringDeserialize"/>
     /// and produce an appropriate generator.
     /// </summary>
     /// <remarks>
+    /// Before serializing/deserializing, you must register "tags" with the Serializer, which will be used to identify
+    /// the type as it is deserialized.  No tags are registered by default.
+    ///
+    /// Each IEnhancedRandom implementation has a <see cref="IEnhancedRandom.DefaultTag"/> field, which constitutes the default
+    /// tag that will be used for the generator type, if one is not specified when the registration is performed.  Therefore,
+    /// if the default tag works for your use case, registration requires nothing more than calling <see cref="RegisterTag(IEnhancedRandom)"/>.
+    /// If you need to specify a different tag, there is an overload available which takes a tag.  Other functions are also provided
+    /// which fit various use cases, including overwriting registered tags, removing tags, etc.
+    ///
+    /// You may also just call the <see cref="RegisterShaiRandomDefaultTags()"/> function, to register the default tags for every generator
+    /// implementation in ShaiRandom.
+    ///
     /// If you have custom <see cref="IEnhancedRandom"/> implementations, provided they implement <see cref="IEnhancedRandom.StringSerialize"/>,
     /// <see cref="IEnhancedRandom.StringDeserialize"/>, and <see cref="IEnhancedRandom.Copy"/>, you may register them to function with this
-    /// serializer by calling <see cref="RegisterTag"/>.
-    ///
-    /// This only needs to be done once per type, and is typically performed inside a static class constructor for your RNG type.  The generator
-    /// implementations in ShaiRandom do this same thing; feel free to look at any of them for an example.
+    /// serializer by calling RegisterTag or any of the other tag registration functions.
     /// </remarks>
     public static class Serializer
     {
-        private static readonly Dictionary<string, IEnhancedRandom> s_tags = new Dictionary<string, IEnhancedRandom>();
+        private static readonly Dictionary<string, IEnhancedRandom> s_tagsToGenerators = new Dictionary<string, IEnhancedRandom>();
+        private static readonly Dictionary<Type, string> s_typesToTags = new Dictionary<Type, string>();
 
+        #region Tag Registration/Management
         /// <summary>
-        /// List of tags registered to the serializer.  Register a type to its tag with <see cref="RegisterTag"/>.
+        /// Registers an instance of an IEnhancedRandom implementation by its string <see cref="IEnhancedRandom.DefaultTag"/>.
         /// </summary>
-        public static IReadOnlyDictionary<string, IEnhancedRandom> Tags => s_tags;
+        /// <exception cref="ArgumentException">
+        /// The type of generator given already had a tag, the generator's DefaultTag was already registered to a generator, or the generator's
+        /// DefaultTag contained invalid characters.
+        /// </exception>
+        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
+        /// as long as it is non-null and has a valid value for <see cref="IEnhancedRandom.DefaultTag"/>.</param>
+        public static void RegisterTag(IEnhancedRandom instance) => RegisterTag(instance.DefaultTag, instance);
 
         /// <summary>
-        /// Registers an instance of an IEnhancedRandom implementation by its string <see cref="IEnhancedRandom.Tag"/>.
+        /// Registers an instance of an IEnhancedRandom implementation to the tag specified.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// The type of generator given already had a tag, the given tag was already registered to a generator, or the generator's
+        /// DefaultTag contained invalid characters.
+        /// </exception>
+        /// <param name="tag">The tag to register to the given instance's type.</param>
+        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
+        /// as long as it is non-null and has a valid value for <see cref="IEnhancedRandom.DefaultTag"/>.</param>
+        public static void RegisterTag(string tag, IEnhancedRandom instance)
+        {
+            var type = instance.GetType();
+            if (s_typesToTags.ContainsKey(type))
+                throw new ArgumentException(
+                    $"Tried to register a generator of type {type.Name} with tag {tag}, but that generator type was already associated with a tag: {s_typesToTags[type]}",
+                    nameof(instance));
+            if (s_tagsToGenerators.ContainsKey(tag))
+                throw new ArgumentException(
+                    $"Tried to register a generator of type {type.Name} with tag {tag}, but that tag was already associated with a different generator type: {s_tagsToGenerators[tag].GetType().Name}",
+                    nameof(tag));
+            if (tag.Contains('`'))
+                throw new ArgumentException(
+                    $"Tried to register a generator of type {type.Name} with tag {tag}, but tags cannot not contain the '`' character.");
+
+            s_tagsToGenerators.Add(tag, instance);
+            s_typesToTags.Add(type, tag);
+        }
+
+        /// <summary>
+        /// Tries to register an instance of an IEnhancedRandom implementation by its string <see cref="IEnhancedRandom.DefaultTag"/>.
         /// </summary>
         /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
-        /// as long as it is non-null and has a four-character <see cref="IEnhancedRandom.Tag"/>.</param>
+        /// as long as it is non-null and has a valid value for <see cref="IEnhancedRandom.DefaultTag"/>.</param>
         /// <returns>Returns true if the tag was successfully registered for the first time, or false if the tags are unchanged.</returns>
-        public static bool RegisterTag(IEnhancedRandom instance)
+        public static bool TryRegisterTag(IEnhancedRandom instance) => TryRegisterTag(instance.DefaultTag, instance);
+
+        /// <summary>
+        /// Tries to register an instance of an IEnhancedRandom implementation to the tag specified.
+        /// </summary>
+        /// <param name="tag">The tag to register for generators of the given instance's type.</param>
+        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
+        /// as long as it is non-null.</param>
+        /// <returns>Returns true if the tag was successfully registered for the first time, or false if the tags are unchanged.</returns>
+        public static bool TryRegisterTag(string tag, IEnhancedRandom instance)
         {
-            if (s_tags.ContainsKey(instance.Tag)) return false;
-            if (instance.Tag.Length != 0)
-            {
-                s_tags.Add(instance.Tag, instance);
-                return true;
-            }
-            return false;
+            var type = instance.GetType();
+            if (s_tagsToGenerators.ContainsKey(tag) || s_typesToTags.ContainsKey(type) || tag.Contains('`')) return false;
+            s_tagsToGenerators.Add(tag, instance);
+            s_typesToTags.Add(type, tag);
+            return true;
         }
+
+        /// <summary>
+        /// Registers an instance of an IEnhancedRandom implementation by its string <see cref="IEnhancedRandom.DefaultTag"/>,
+        /// overwriting any conflicting tag or type registrations.
+        /// </summary>
+        /// <remarks>
+        /// This function will overwrite _both_ conflicting tags AND conflicting types; eg. if the instance's DefaultTag
+        /// is registered to a different type, that type's registration will be replaced, AND if the type of the instance
+        /// given is already registered to a different tag, that registration will be replaced with this one.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// The generator's DefaultTag contained invalid characters.
+        /// </exception>
+        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
+        /// as long as it is non-null and has a valid value for <see cref="IEnhancedRandom.DefaultTag"/>.</param>
+        public static void ForceRegisterTag(IEnhancedRandom instance)
+            => ForceRegisterTag(instance.DefaultTag, instance);
+
+        /// <summary>
+        /// Registers an instance of an IEnhancedRandom implementation to the tag specified,
+        /// overwriting any conflicting tag or type registrations.
+        /// </summary>
+        /// <remarks>
+        /// This function will overwrite _both_ conflicting tags AND conflicting types; eg. if the given tag is registered
+        /// to a different type, that type's registration will be replaced, AND if the type of the instance given is already
+        /// registered to a different tag, that registration will be replaced with this one.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// The given tag contained invalid characters.
+        /// </exception>
+        /// <param name="tag">The tag to register for generators of the given instance's type.</param>
+        /// <param name="instance">An instance of an IEnhancedRandom implementation, which will be copied as needed; its state does not matter,
+        /// as long as it is non-null and has a valid value for <see cref="IEnhancedRandom.DefaultTag"/>.</param>
+        public static void ForceRegisterTag(string tag, IEnhancedRandom instance)
+        {
+            UnregisterTag(tag);
+            UnregisterTag(instance.GetType());
+            RegisterTag(tag, instance);
+        }
+
+        /// <summary>
+        /// Unregisters any generator type that is registered to the given tag.
+        /// </summary>
+        /// <param name="tag">The tag to unregister</param>
+        /// <returns>True if the tag was found and unregistered; false if the tag given isn't found.</returns>
+        public static bool UnregisterTag(string tag)
+        {
+            if (!s_tagsToGenerators.TryGetValue(tag, out var instance))
+                return false;
+
+            s_typesToTags.Remove(instance.GetType());
+            s_tagsToGenerators.Remove(tag);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Unregisters the given type's tag, whatever that tag may be.
+        /// </summary>
+        /// <param name="generatorType">The type to unregister.</param>
+        /// <returns>True if the type was found and its tag was unregistered; false if the generator type given was never registered.</returns>
+        public static bool UnregisterTag(Type generatorType)
+        {
+            if (!s_typesToTags.TryGetValue(generatorType, out var tag))
+                return false;
+
+            s_tagsToGenerators.Remove(tag);
+            s_typesToTags.Remove(generatorType);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Unregisters the given type's tag, whatever that tag may be.
+        /// </summary>
+        /// <typeparam name="T">Type of the generator to unregister.</typeparam>
+        /// <returns>True if the type was found and its tag was unregistered; false if the generator type given was never registered.</returns>
+        public static bool UnregisterTag<T>() where T : IEnhancedRandom
+            => UnregisterTag(typeof(T));
+
+        /// <summary>
+        /// Gets the tag registered for the given type.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">No tag was registered for the given type.</exception>
+        /// <param name="generatorType">Type to retrieve the registered tag for.</param>
+        /// <returns>The tag registered for the given type</returns>
+        public static string GetTag(Type generatorType) => s_typesToTags[generatorType];
+
+        /// <summary>
+        /// Gets the tag registered for the given type.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">No tag was registered for the given type.</exception>
+        /// <typeparam name="T">Type to retrieve the registered tag for.</typeparam>
+        /// <returns>The tag registered for the given type</returns>
+        public static string GetTag<T>() where T : IEnhancedRandom
+            => GetTag(typeof(T));
+
+        /// <summary>
+        /// Gets the tag registered for the given instance's type.
+        /// </summary>
+        /// <exception cref="KeyNotFoundException">No tag was registered for the type of the given instance.</exception>
+        /// <param name="instance">Instance to retrieve the tag for.</param>
+        /// <returns>The tag registered for the runtime type of the given instance.</returns>
+        public static string GetTag(IEnhancedRandom instance) => GetTag(instance.GetType());
+
+        /// <summary>
+        /// Tries to get the tag registered for the given type.
+        /// </summary>
+        /// <param name="generatorType">Type to retrieve the registered tag for.</param>
+        /// <param name="tag">Out-variable in which to place the retrieved tag, or null if the type had no registered tag.</param>
+        /// <returns>True if a tag was found; false otherwise.</returns>
+        public static bool TryGetTag(Type generatorType, [MaybeNullWhen(false)] out string tag)
+            => s_typesToTags.TryGetValue(generatorType, out tag);
+
+        /// <summary>
+        /// Tries to get the tag registered for the given type.
+        /// </summary>
+        /// <typeparam name="T">Type to retrieve the registered tag for.</typeparam>
+        /// <param name="tag">Out-variable in which to place the retrieved tag, or null if the type had no registered tag.</param>
+        /// <returns>True if a tag was found; false otherwise.</returns>
+        public static bool TryGetTag<T>([MaybeNullWhen(false)] out string tag) where T : IEnhancedRandom
+            => TryGetTag(typeof(T), out tag);
+
+        /// <summary>
+        /// Tries to get the tag registered for the type of the given generator instance.
+        /// </summary>
+        /// <param name="instance">The instance for which to retrieve the registered tag.</param>
+        /// <param name="tag">Out-variable in which to place the retrieved tag, or null if the instance's runtime type had no registered tag.</param>
+        /// <returns>True if a tag was found; false otherwise.</returns>
+        public static bool TryGetTag(IEnhancedRandom instance, [MaybeNullWhen(false)] out string tag)
+            => TryGetTag(instance.GetType(), out tag);
+
+        /// <summary>
+        /// Gets the tag registered for the given type, or null if no tag is registered for that type.
+        /// </summary>
+        /// <param name="generatorType">Type to retrieve the registered tag for.</param>
+        /// <returns>The tag registered for the given type, or null if no tag was registered for the given type.</returns>
+        public static string? GetTagOrNull(Type generatorType) => s_typesToTags.GetValueOrDefault(generatorType);
+
+        /// <summary>
+        /// Gets the tag registered for the given type, or null if no tag is registered for that type.
+        /// </summary>
+        /// <typeparam name="T">Type to retrieve the registered tag for.</typeparam>
+        /// <returns>The tag registered for the given type, or null if no tag was registered for the given type.</returns>
+        public static string? GetTagOrNull<T>() where T : IEnhancedRandom
+            => GetTagOrNull(typeof(T));
+
+        /// <summary>
+        /// Gets the tag registered for the type of the given instance, or null if no tag is registered for that type.
+        /// </summary>
+        /// <param name="instance">Generator for which to retrieve the tag.</param>
+        /// <returns>The tag registered for the runtime type of the given instance, or null if no tag was registered for that type.</returns>
+        public static string? GetTagOrNull(IEnhancedRandom instance) => GetTagOrNull(instance.GetType());
+        #endregion
+
+        #region Standard Generator Tag Registration
+        /// <summary>
+        /// Registers the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.
+        /// </summary>
+        /// <exception cref="ArgumentException">One of the tags failed to register.</exception>
+        /// <remarks>
+        /// This function will throw an exception if any of the tags are already registered to their type,
+        /// or if any of the tags have already been registered to something else.  For a more tolerant way of setting
+        /// tags, see the <see cref="TryRegisterShaiRandomDefaultTags"/> function.
+        /// </remarks>
+        public static void RegisterShaiRandomDefaultTags()
+        {
+            foreach (var instance in GetSerializerInstancesForShaiRandomGens())
+                RegisterTag(instance);
+        }
+
+        /// <summary>
+        /// Tries to register the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.
+        /// </summary>
+        /// <remarks>
+        /// This function will return false if ANY of the tags failed to set; however it will attempt to set tags for
+        /// ALL the generators in ShaiRandom, even if one fails.  If you wish to forcibly set all the built-in ShaiRandom
+        /// generators to be registered to their tag, see the <see cref="ForceRegisterShaiRandomDefaultTags"/> function.
+        /// </remarks>
+        public static bool TryRegisterShaiRandomDefaultTags()
+        {
+            bool allSucceeded = true;
+            foreach (var instance in GetSerializerInstancesForShaiRandomGens())
+                allSucceeded &= TryRegisterTag(instance);
+
+            return allSucceeded;
+        }
+
+        /// <summary>
+        /// Registers the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom, overwriting any
+        /// existing registrations for those types and tags.
+        /// </summary>
+        /// <remarks>
+        /// This function will unregister any conflicting tags, and replace them with the default tags, for all
+        /// ShaiRandom implementations.  For a way of setting tags that is more tolerate to existing registrations,
+        /// see <see cref="TryRegisterShaiRandomDefaultTags"/>.
+        /// </remarks>
+        public static void ForceRegisterShaiRandomDefaultTags()
+        {
+            foreach (var instance in GetSerializerInstancesForShaiRandomGens())
+                ForceRegisterTag(instance);
+        }
+
+        private static IEnumerable<IEnhancedRandom> GetSerializerInstancesForShaiRandomGens()
+        {
+            // Generators
+            yield return new DistinctRandom(1UL);
+            yield return new FourWheelRandom(1UL, 1UL, 1UL, 1UL);
+            yield return new KnownSeriesRandom();
+            yield return new LaserRandom(1UL, 1UL);
+            yield return MaxRandom.Instance;
+            yield return MinRandom.Instance;
+            yield return new MizuchiRandom(1UL, 1UL);
+            yield return new RomuTrioRandom(1UL, 1UL, 1UL);
+            yield return new StrangerRandom(1UL, 1UL, 1UL, 1UL);
+            yield return new TricycleRandom(1UL, 1UL, 1UL);
+            yield return new TrimRandom(1UL, 1UL, 1UL, 1UL);
+            yield return new Xoshiro256StarStarRandom(1UL, 1UL, 1UL, 1UL);
+
+            // Wrappers
+            yield return new ArchivalWrapper(new DistinctRandom(1UL));
+            yield return new ReversingWrapper(new DistinctRandom(1UL));
+            yield return new TRGeneratorWrapper(new DistinctRandom(1UL));
+        }
+        #endregion
 
         /// <summary>
         /// Produces a string representing the serialized form of the given RNG, by calling its <see cref="IEnhancedRandom.StringSerialize"/>
@@ -57,10 +335,8 @@ namespace ShaiRandom
         /// this returns a new IEnhancedRandom with the same implementation and state it had when it was serialized.
         /// </summary>
         /// <remarks>
-        /// This handles all IEnhancedRandom implementations in this library, including <see cref="TRGeneratorWrapper"/>,
-        /// <see cref="ReversingWrapper"/>, and <see cref="ArchivalWrapper"/>.  It will also work with arbitrary custom
-        /// IEnhancedRandom implementations, provided they implement StringSerialize, StringDeserialize, and Copy, and register
-        /// their tag via <see cref="RegisterTag"/>.
+        /// This function will support any IEnhancedRandom implementation that has been registered with the serializer,
+        /// provided that it had the same tag registered to it when it was serialized that it does when this function is called.
         ///
         /// This function takes as input a ReadOnlySpan of char, which allows data to be any string or some more specialized types.
         /// </remarks>
@@ -76,7 +352,7 @@ namespace ShaiRandom
             // When the feature linked here is implemented, we could get around this:
             // https://github.com/dotnet/runtime/issues/27229
             string tagData = new string(data[..idx]);
-            return s_tags[tagData].Copy().StringDeserialize(data[idx..]);
+            return s_tagsToGenerators[tagData].Copy().StringDeserialize(data[idx..]);
         }
     }
 }

--- a/ShaiRandom/Wrappers/ArchivalWrapper.cs
+++ b/ShaiRandom/Wrappers/ArchivalWrapper.cs
@@ -28,11 +28,7 @@ namespace ShaiRandom.Wrappers
         /// <summary>
         /// The identifying tag here is "ArW", which is a different length to indicate the tag is a wrapper.
         /// </summary>
-        public string Tag => "ArW";
-        static ArchivalWrapper()
-        {
-            Serializer.RegisterTag(new ArchivalWrapper(new DistinctRandom(1UL)));
-        }
+        public string DefaultTag => "ArW";
 
         /// <summary>
         /// The ShaiRandom IEnhancedRandom being wrapped, which must never be null.
@@ -524,7 +520,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public string StringSerialize()
         {
-            var ser = new StringBuilder(Tag);
+            var ser = new StringBuilder(Serializer.GetTag(this));
             ser.Append('`');
             ser.Append(MakeArchivedSeries().StringSerialize());
             ser.Append('~');
@@ -538,7 +534,7 @@ namespace ShaiRandom.Wrappers
         {
             int breakPoint = data.IndexOf("`~") + 2;
             KnownSeriesRandom ksr = new KnownSeriesRandom();
-            ksr.StringDeserialize(data[(Tag.Length+1)..]);
+            ksr.StringDeserialize(data[1..]);
             Wrapped = Serializer.Deserialize(data[breakPoint..]);
             _boolSeries.Clear();
             _byteSeries.Clear();

--- a/ShaiRandom/Wrappers/ArchivalWrapper.cs
+++ b/ShaiRandom/Wrappers/ArchivalWrapper.cs
@@ -31,7 +31,7 @@ namespace ShaiRandom.Wrappers
         public string Tag => "ArW";
         static ArchivalWrapper()
         {
-            AbstractRandom.RegisterTag(new ArchivalWrapper(new DistinctRandom(1UL)));
+            Serializer.RegisterTag(new ArchivalWrapper(new DistinctRandom(1UL)));
         }
 
         /// <summary>
@@ -539,7 +539,7 @@ namespace ShaiRandom.Wrappers
             int breakPoint = data.IndexOf("`~") + 2;
             KnownSeriesRandom ksr = new KnownSeriesRandom();
             ksr.StringDeserialize(data[(Tag.Length+1)..]);
-            Wrapped = AbstractRandom.Deserialize(data[breakPoint..]);
+            Wrapped = Serializer.Deserialize(data[breakPoint..]);
             _boolSeries.Clear();
             _byteSeries.Clear();
             _doubleSeries.Clear();

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -23,7 +23,7 @@ namespace ShaiRandom.Wrappers
         public override string Tag => "RvW";
         static ReversingWrapper()
         {
-            RegisterTag(new ReversingWrapper(new DistinctRandom(1UL)));
+            Serializer.RegisterTag(new ReversingWrapper(new DistinctRandom(1UL)));
         }
 
         /// <summary>
@@ -107,7 +107,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
-            Wrapped = Deserialize(data[1..]);
+            Wrapped = Serializer.Deserialize(data[1..]);
             return this;
         }
 

--- a/ShaiRandom/Wrappers/ReversingWrapper.cs
+++ b/ShaiRandom/Wrappers/ReversingWrapper.cs
@@ -20,11 +20,7 @@ namespace ShaiRandom.Wrappers
         /// <summary>
         /// The identifying tag here is "RvW", which is a different length to indicate the tag is a wrapper.
         /// </summary>
-        public override string Tag => "RvW";
-        static ReversingWrapper()
-        {
-            Serializer.RegisterTag(new ReversingWrapper(new DistinctRandom(1UL)));
-        }
+        public override string DefaultTag => "RvW";
 
         /// <summary>
         /// The ShaiRandom generator being wrapped, which must never be null.
@@ -96,7 +92,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public override string StringSerialize()
         {
-            var ser = new StringBuilder(Tag);
+            var ser = new StringBuilder(Serializer.GetTag(this));
             ser.Append('`');
             ser.Append(Wrapped.StringSerialize());
             ser.Append('`');

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -19,11 +19,7 @@ namespace ShaiRandom.Wrappers
         /// <summary>
         /// The identifying tag here is "TRW", which is a different length to indicate the tag is a wrapper.
         /// </summary>
-        public override string Tag => "TRW";
-        static TRGeneratorWrapper()
-        {
-            Serializer.RegisterTag(new TRGeneratorWrapper(new DistinctRandom(1UL)));
-        }
+        public override string DefaultTag => "TRW";
 
         /// <summary>
         /// The wrapped RNG, which must never be null.
@@ -85,7 +81,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public override string StringSerialize()
         {
-            var ser = new StringBuilder(Tag);
+            var ser = new StringBuilder(Serializer.GetTag(this));
             ser.Append('`');
             ser.Append(Wrapped.StringSerialize());
             ser.Append('`');

--- a/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
+++ b/ShaiRandom/Wrappers/TRGeneratorWrapper.cs
@@ -22,7 +22,7 @@ namespace ShaiRandom.Wrappers
         public override string Tag => "TRW";
         static TRGeneratorWrapper()
         {
-            RegisterTag(new TRGeneratorWrapper(new DistinctRandom(1UL)));
+            Serializer.RegisterTag(new TRGeneratorWrapper(new DistinctRandom(1UL)));
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace ShaiRandom.Wrappers
         /// <inheritdoc />
         public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
         {
-            Wrapped = Deserialize(data[1..]);
+            Wrapped = Serializer.Deserialize(data[1..]);
             return this;
         }
 


### PR DESCRIPTION
# Changes
- Pulled the `Deserialize` functions and tag-related items out of `AbstractRandom` and into a new class called `Serializer`
- Modified the `Tag` field of `IEnhancedRandom` to be called `DefaultTag`
     - This field now represents the _default_ tag, which is used only if no other tag is specified when the type is registered with the serializer
- Made the serializer, rather than the tag fields of generators, the authoritative source for what the tag is for a generator type
    - Serializer now maintains mapping of both tag to instance, and type to tag.
    - Serializer has functions to retrieve tag by type or based on an instance, as well as remove and modify tags.
    - Note: This means that `StringSerialize` implementations looking for their tag must now ask the serializer, instead of using their DefaultTag.
- Added functionality for user to use custom tags
- Removed the static constructors that called register tag
    - This method of setting tags was bugged since static constructors aren't run until an instance of the type is initialized (in most runtimes)
- Changed the serialization system to use "opt-in" registration for tags
    - No tags are registered automatically
    - The user has several different styles of "register" functions to call, which they can use to register generator types with either their default tags, or custom tags
    - Convenience functions also exist to allow the user to register the default tags for all ShaiRandom generators
- Modified `RegisterTag` to throw exception if a tag was already registered (consistency with C# collection APIs; see other registration functions and below discussion)
- Added `TryRegisterTag`, which has the functionality previously in `RegisterTag` (returns false on fail)
- Added `ForceRegisterTag`, which is yet another way to set tags, that will forcibly replace any conflicts
- Fixed minor bug in `ArchivalWrapper` deserialization

# Goals/EndState
The primary goal of this PR is to fix two significant shortcomings in the current serialization implementation:

1. The current implementation is very much buggy as soon as you start deserializing generators from strings which you did not serialize during the lifetime of the current application.  This was due to static constructors being used to register tags; those constructors were not called until the type itself was instantiated or used.
2. The implementation failed to give the user easy control over how to handle situations such as generator tags from separate libraries conflicting.

To do this, several changes were made to serialization.  First, to alleveate confusion and the creation of large files during this process, the static serialization-related components of AbstractRandom have been pulled out into a `Serializer` class.

Second, ShaiRandom no longer attempts to automatically register tags for its generator types.  Instead, the serializer uses "opt-in" serialization, meaning a user has to explicitly register tags for anything they want to serialize or deserialize.  Functions to allow this now exist in the `Serializer` class; and a user can use them to register tags with a variety of different APIs and conflict resolution strategies.  Users are able to either specify a tag to associate, or omit the tag and just provide a generator instance (in which case its default tag is used).  There are also convenience functions which allow the user to register _all_ default tags for ShaiRandom generators at once.  Note that a custom class has been added to the unit tests which ensures that the registration functions have been called before the unit tests run.

Third, the `Tag` field of `IEnhancedRandom` is no longer the only, authoritative source for what the tag is for a type.  Instead, those values only serve as uniform defaults (used if the user doesn't pass a custom value to the `Serializer` registration functions).  The `Tag` field, as such, has been renamed to `DefaultTag`.  Instead, the `Serializer` is responsible for mapping types to the tag they will use, and maintains this mapping along with the data it used to maintain.  Note that this impacts generator implementations, in that, in functions such as `StringSerialize` and `StringDeserialize`, if/when the function needs to use its tag for something, it must ask the serializer what its tag should be via `GetTag`; using the `DefaultTag` will create bugs (which are not unit tested for at the moment).

Fourth, the API of `Serializer` is drastically expanded compared to what was offered in `AbstractRandom` previously, and some functions have been modified to adhere as closely as possible to typical C# paradigms.  To this end, the `RegisterTag` function now throws exceptions if the registration encounters an issue, rather than returning false.  However, there is now a function called `TryRegisterTag` which maintains the old behavior of returning true/false.

This paradigm of having the "normal" version of an operation throw exception, and then a version of the function with "Try" appended to the front which returns true/false instead of exceptions, is fairly common in C#; the exact same paradigm is used in C#'s Dictionary, as well as some other data structures (see `Dictionary.Add` vs `Dictionary.TryAdd`, `int.Parse` vs `int.TryParse`, etc).  Some details on the pattern can be found [here](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/exceptions-and-performance); it seems to apply to this situation, since a collection of tag-to-type associations is effectively a collection, and these operations fit the could-fail pattern.  Additionally, a _third_ function has been added called `ForceRegisterTag`, which handles conflicts by removing any conflicting tags and replacing them with the specified one.

Similarly, the API has added many other functions, pertaining to removing tags, replacing tags, and retrieving tags, and these APIs all try to follow a similar pattern.  In this way, a user is able to be very specific about what sort of conflict resolution behavior they want; which can be important in enabling them to handle conflicting tags and the like.

All of the unit tests related to serialization are passing, however there are still quite a few unit tests that could be added to test things like custom tags, etc.  Some effort will be required to add these, as since XUnit multi-threads its unit tests, the opt-in serialization architecture can create some challenges here.