### PR TITLE
Uncommented TroschuetzCompat Code/Readied for Release

### DIFF
--- a/ShaiRandom.TroschuetzCompat/Distributions/TRContinuousDistributionWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Distributions/TRContinuousDistributionWrapper.cs
@@ -3,27 +3,27 @@ using Troschuetz.Random;
 
 namespace ShaiRandom.TroschuetzCompat.Distributions
 {
-    // /// <summary>
-    // /// Wraps a ShaiRandom IEnhancedContinuousDistribution object so it can also be used as a Troschuetz.Random IContinuousDistribution.
-    // /// </summary>
-    // /// <remarks>
-    // /// This class implements both IContinuousDistribution and IEnhancedContinuousDistribution.  Any IEnhancedDistribution member is
-    // /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all IDistribution methods are
-    // /// explicitly implemented and are implemented in terms of IEnhancedDistribution methods.
-    // /// </remarks>
-    // public class TRContinuousDistributionWrapper : TRDistributionWrapper, IContinuousDistribution, IEnhancedContinuousDistribution
-    // {
-    //     /// <summary>
-    //     /// The ShaiRandom distribution being wrapped.
-    //     /// </summary>
-    //     public new IEnhancedContinuousDistribution Wrapped => (IEnhancedContinuousDistribution)base.Wrapped;
-    //
-    //     /// <summary>
-    //     /// Creates a new wrapper which wraps the given ShaiRandom distribution.
-    //     /// </summary>
-    //     /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
-    //     public TRContinuousDistributionWrapper(IEnhancedContinuousDistribution wrapped)
-    //         : base(wrapped)
-    //     { }
-    // }
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedContinuousDistribution object so it can also be used as a Troschuetz.Random IContinuousDistribution.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IContinuousDistribution and IEnhancedContinuousDistribution.  Any IEnhancedDistribution member is
+    /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all IDistribution methods are
+    /// explicitly implemented and are implemented in terms of IEnhancedDistribution methods.
+    /// </remarks>
+    public class TRContinuousDistributionWrapper : TRDistributionWrapper, IContinuousDistribution, IEnhancedContinuousDistribution
+    {
+        /// <summary>
+        /// The ShaiRandom distribution being wrapped.
+        /// </summary>
+        public new IEnhancedContinuousDistribution Wrapped => (IEnhancedContinuousDistribution)base.Wrapped;
+
+        /// <summary>
+        /// Creates a new wrapper which wraps the given ShaiRandom distribution.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
+        public TRContinuousDistributionWrapper(IEnhancedContinuousDistribution wrapped)
+            : base(wrapped)
+        { }
+    }
 }

--- a/ShaiRandom.TroschuetzCompat/Distributions/TRDiscreteDistributionWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Distributions/TRDiscreteDistributionWrapper.cs
@@ -3,34 +3,34 @@ using Troschuetz.Random;
 
 namespace ShaiRandom.TroschuetzCompat.Distributions
 {
-    // /// <summary>
-    // /// Wraps a ShaiRandom IEnhancedDiscreteDistribution object so it can also be used as a Troschuetz.Random IDiscreteDistribution.
-    // /// </summary>
-    // /// <remarks>
-    // /// This class implements both IDiscreteDistribution and IEnhancedDiscreteDistribution.  Any ShaiRandom distribution member is
-    // /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all Troschuetz methods are
-    // /// explicitly implemented and are implemented in terms of ShaiRandom distribution methods.
-    // /// </remarks>
-    // public class TRDiscreteDistributionWrapper : TRDistributionWrapper, IDiscreteDistribution, IEnhancedDiscreteDistribution
-    // {
-    //     /// <summary>
-    //     /// The ShaiRandom distribution being wrapped.
-    //     /// </summary>
-    //     public new IEnhancedDiscreteDistribution Wrapped => (IEnhancedDiscreteDistribution)base.Wrapped;
-    //
-    //     /// <summary>
-    //     /// Creates a new wrapper which wraps the given ShaiRandom distribution.
-    //     /// </summary>
-    //     /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
-    //     public TRDiscreteDistributionWrapper(IEnhancedDiscreteDistribution wrapped)
-    //         : base(wrapped)
-    //     { }
-    //
-    //     /// <inheritdoc />
-    //     public int NextInt() => Wrapped.NextInt();
-    //
-    //     #region IDiscreteDistribution Explicit Implementation
-    //     int IDiscreteDistribution.Next() => NextInt();
-    //     #endregion
-    // }
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedDiscreteDistribution object so it can also be used as a Troschuetz.Random IDiscreteDistribution.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IDiscreteDistribution and IEnhancedDiscreteDistribution.  Any ShaiRandom distribution member is
+    /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all Troschuetz methods are
+    /// explicitly implemented and are implemented in terms of ShaiRandom distribution methods.
+    /// </remarks>
+    public class TRDiscreteDistributionWrapper : TRDistributionWrapper, IDiscreteDistribution, IEnhancedDiscreteDistribution
+    {
+        /// <summary>
+        /// The ShaiRandom distribution being wrapped.
+        /// </summary>
+        public new IEnhancedDiscreteDistribution Wrapped => (IEnhancedDiscreteDistribution)base.Wrapped;
+
+        /// <summary>
+        /// Creates a new wrapper which wraps the given ShaiRandom distribution.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
+        public TRDiscreteDistributionWrapper(IEnhancedDiscreteDistribution wrapped)
+            : base(wrapped)
+        { }
+
+        /// <inheritdoc />
+        public int NextInt() => Wrapped.NextInt();
+
+        #region IDiscreteDistribution Explicit Implementation
+        int IDiscreteDistribution.Next() => NextInt();
+        #endregion
+    }
 }

--- a/ShaiRandom.TroschuetzCompat/Distributions/TRDistributionWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Distributions/TRDistributionWrapper.cs
@@ -5,77 +5,77 @@ using Troschuetz.Random;
 
 namespace ShaiRandom.TroschuetzCompat.Distributions
 {
-    // /// <summary>
-    // /// Wraps a ShaiRandom IEnhancedDistribution object so it can also be used as a Troschuetz.Random IDistribution.
-    // /// </summary>
-    // /// <remarks>
-    // /// This class implements both IDistribution and IEnhancedDistribution.  Any IEnhancedDistribution member is
-    // /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all IDistribution methods are
-    // /// explicitly implemented and are implemented in terms of IEnhancedDistribution methods.
-    // /// </remarks>
-    // public class TRDistributionWrapper : IDistribution, IEnhancedDistribution
-    // {
-    //     /// <summary>
-    //     /// The ShaiRandom distribution being wrapped.
-    //     /// </summary>
-    //     public IEnhancedDistribution Wrapped { get; }
-    //
-    //     /// <summary>
-    //     /// Creates a new wrapper which wraps the given ShaiRandom distribution.
-    //     /// </summary>
-    //     /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
-    //     public TRDistributionWrapper(IEnhancedDistribution wrapped) => Wrapped = wrapped;
-    //
-    //     /// <inheritdoc />
-    //     public IEnhancedRandom Generator => Wrapped.Generator;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.Maximum" />
-    //     public double Maximum => Wrapped.Maximum;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.Mean" />
-    //     public double Mean => Wrapped.Mean;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.Median" />
-    //     public double Median => Wrapped.Median;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.Minimum" />
-    //     public double Minimum => Wrapped.Minimum;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.Mode" />
-    //     public double[] Mode => Wrapped.Mode;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.Variance" />
-    //     public double Variance => Wrapped.Variance;
-    //
-    //     /// <inheritdoc cref="IEnhancedDistribution.NextDouble" />
-    //     public double NextDouble() => Wrapped.NextDouble();
-    //
-    //     /// <inheritdoc />
-    //     public int Steps => Wrapped.Steps;
-    //
-    //     /// <inheritdoc />
-    //     public int ParameterCount => Wrapped.ParameterCount;
-    //
-    //     /// <inheritdoc />
-    //     public string ParameterName(int index) => Wrapped.ParameterName(index);
-    //
-    //     /// <inheritdoc />
-    //     public double ParameterValue(int index) => Wrapped.ParameterValue(index);
-    //
-    //     /// <inheritdoc />
-    //     public void SetParameterValue(int index, double value) => Wrapped.SetParameterValue(index, value);
-    //
-    //     #region IDistribution Explicit Implementations
-    //
-    //     bool IDistribution.CanReset => false;
-    //     bool IDistribution.Reset() => false;
-    //
-    //     IGenerator IDistribution.Generator => Wrapped.Generator switch
-    //     {
-    //         IGenerator trGen => trGen,
-    //         _ => new TRGeneratorWrapper(Wrapped.Generator)
-    //     };
-    //
-    //     #endregion
-    // }
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedDistribution object so it can also be used as a Troschuetz.Random IDistribution.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IDistribution and IEnhancedDistribution.  Any IEnhancedDistribution member is
+    /// implemented by simply forwarding to the ShaiRandom distribution being wrapped;  all IDistribution methods are
+    /// explicitly implemented and are implemented in terms of IEnhancedDistribution methods.
+    /// </remarks>
+    public class TRDistributionWrapper : IDistribution, IEnhancedDistribution
+    {
+        /// <summary>
+        /// The ShaiRandom distribution being wrapped.
+        /// </summary>
+        public IEnhancedDistribution Wrapped { get; }
+
+        /// <summary>
+        /// Creates a new wrapper which wraps the given ShaiRandom distribution.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom distribution to wrap.</param>
+        public TRDistributionWrapper(IEnhancedDistribution wrapped) => Wrapped = wrapped;
+
+        /// <inheritdoc />
+        public IEnhancedRandom Generator => Wrapped.Generator;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Maximum" />
+        public double Maximum => Wrapped.Maximum;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Mean" />
+        public double Mean => Wrapped.Mean;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Median" />
+        public double Median => Wrapped.Median;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Minimum" />
+        public double Minimum => Wrapped.Minimum;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Mode" />
+        public double[] Mode => Wrapped.Mode;
+
+        /// <inheritdoc cref="IEnhancedDistribution.Variance" />
+        public double Variance => Wrapped.Variance;
+
+        /// <inheritdoc cref="IEnhancedDistribution.NextDouble" />
+        public double NextDouble() => Wrapped.NextDouble();
+
+        /// <inheritdoc />
+        public int Steps => Wrapped.Steps;
+
+        /// <inheritdoc />
+        public int ParameterCount => Wrapped.ParameterCount;
+
+        /// <inheritdoc />
+        public string ParameterName(int index) => Wrapped.ParameterName(index);
+
+        /// <inheritdoc />
+        public double ParameterValue(int index) => Wrapped.ParameterValue(index);
+
+        /// <inheritdoc />
+        public void SetParameterValue(int index, double value) => Wrapped.SetParameterValue(index, value);
+
+        #region IDistribution Explicit Implementations
+
+        bool IDistribution.CanReset => false;
+        bool IDistribution.Reset() => false;
+
+        IGenerator IDistribution.Generator => Wrapped.Generator switch
+        {
+            IGenerator trGen => trGen,
+            _ => new TRGeneratorWrapper(Wrapped.Generator)
+        };
+
+        #endregion
+    }
 }

--- a/ShaiRandom.TroschuetzCompat/Generators/TRGeneratorWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Generators/TRGeneratorWrapper.cs
@@ -5,116 +5,116 @@ using Troschuetz.Random;
 
 namespace ShaiRandom.TroschuetzCompat.Generators
 {
-    // /// <summary>
-    // /// Wraps a ShaiRandom IEnhancedRandom object so it can also be used as a Troschuetz.Random IGenerator.
-    // /// </summary>
-    // /// <remarks>
-    // /// This class implements both IGenerator and IEnhancedRandom.  Any IEnhancedRandom member is implemented by
-    // /// simply forwarding to the ShaiRandom generator being wrapped;  all IGenerator methods are explicitly implemented
-    // /// and are implemented in terms of IEnhancedRandom methods.
-    // /// </remarks>
-    // [System.Serializable]
-    // public class TRGeneratorWrapper : AbstractRandom, IGenerator
-    // {
-    //     /// <summary>
-    //     /// The identifying tag here is "TRW", which is a different length to indicate the tag is a wrapper.
-    //     /// </summary>
-    //     public override string DefaultTag => "TRW";
-    //
-    //     /// <summary>
-    //     /// The wrapped RNG, which must never be null.
-    //     /// </summary>
-    //     public IEnhancedRandom Wrapped { get; set; }
-    //
-    //     /// <summary>
-    //     /// Creates a wrapper around a new FourWheelRandom generator with a random state.
-    //     /// </summary>
-    //     public TRGeneratorWrapper() => Wrapped = new FourWheelRandom();
-    //
-    //     /// <summary>
-    //     /// Creates a wrapper around a new FourWheelRandom generator, whose state will be initialized with the given seed.
-    //     /// </summary>
-    //     /// <param name="seed">Seed to initialize the new generator with.</param>
-    //     public TRGeneratorWrapper(ulong seed) => Wrapped = new FourWheelRandom(seed);
-    //
-    //     /// <summary>
-    //     /// Creates a wrapper around the given ShaiRandom generator.
-    //     /// </summary>
-    //     /// <param name="wrapped">The ShaiRandom generator to wrap.</param>
-    //     public TRGeneratorWrapper(IEnhancedRandom wrapped) => Wrapped = wrapped;
-    //
-    //     /// <inheritdoc />
-    //     public override int StateCount => Wrapped.StateCount;
-    //     /// <inheritdoc />
-    //     public override bool SupportsReadAccess => Wrapped.SupportsReadAccess;
-    //     /// <inheritdoc />
-    //     public override bool SupportsWriteAccess => Wrapped.SupportsWriteAccess;
-    //     /// <inheritdoc />
-    //     public override bool SupportsSkip => Wrapped.SupportsSkip;
-    //     /// <inheritdoc />
-    //     public override bool SupportsPrevious => Wrapped.SupportsPrevious;
-    //
-    //     /// <inheritdoc />
-    //     public override IEnhancedRandom Copy() => new TRGeneratorWrapper(Wrapped.Copy());
-    //     /// <inheritdoc />
-    //     public override double NextDouble() => Wrapped.NextDouble();
-    //     /// <inheritdoc />
-    //     public override ulong NextULong() => Wrapped.NextULong();
-    //     /// <inheritdoc />
-    //     public override ulong SelectState(int selection) => Wrapped.SelectState(selection);
-    //     /// <inheritdoc />
-    //     public override void Seed(ulong seed) => Wrapped.Seed(seed);
-    //     /// <inheritdoc />
-    //     public override void SetState(ulong stateA) => Wrapped.SetState(stateA);
-    //     /// <inheritdoc />
-    //     public override void SetState(ulong stateA, ulong stateB) => Wrapped.SetState(stateA, stateB);
-    //     /// <inheritdoc />
-    //     public override void SetState(ulong stateA, ulong stateB, ulong stateC) => Wrapped.SetState(stateA, stateB, stateC);
-    //     /// <inheritdoc />
-    //     public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Wrapped.SetState(stateA, stateB, stateC, stateD);
-    //     /// <inheritdoc />
-    //     public override void SetState(params ulong[] states) => Wrapped.SetState(states);
-    //     /// <inheritdoc />
-    //     public override ulong Skip(ulong distance) => Wrapped.Skip(distance);
-    //     /// <inheritdoc />
-    //     public override ulong PreviousULong() => Wrapped.PreviousULong();
-    //     /// <inheritdoc />
-    //     public override string StringSerialize()
-    //     {
-    //         var ser = new StringBuilder(Serializer.GetTag(this));
-    //         ser.Append('`');
-    //         ser.Append(Wrapped.StringSerialize());
-    //         ser.Append('`');
-    //
-    //         return ser.ToString();
-    //     }
-    //
-    //     /// <inheritdoc />
-    //     public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
-    //     {
-    //         Wrapped = Serializer.Deserialize(data[1..]);
-    //         return this;
-    //     }
-    //
-    //     #region IGenerator explicit implementation
-    //     bool IGenerator.CanReset => false;
-    //     uint IGenerator.Seed => 1;
-    //     int IGenerator.Next() => Wrapped.NextInt(int.MaxValue);
-    //     int IGenerator.Next(int maxValue) => Wrapped.NextInt(maxValue);
-    //     int IGenerator.Next(int minValue, int maxValue) => Wrapped.NextInt(minValue, maxValue);
-    //     bool IGenerator.NextBoolean() => Wrapped.NextBool();
-    //     void IGenerator.NextBytes(byte[] buffer) => Wrapped.NextBytes(buffer);
-    //     double IGenerator.NextDouble() => Wrapped.NextDouble();
-    //     double IGenerator.NextDouble(double maxValue) => Wrapped.NextDouble(maxValue);
-    //     double IGenerator.NextDouble(double minValue, double maxValue) => Wrapped.NextDouble(minValue, maxValue);
-    //     int IGenerator.NextInclusiveMaxValue() => (int)Wrapped.NextBits(31);
-    //     uint IGenerator.NextUInt() => Wrapped.NextUInt(uint.MaxValue);
-    //     uint IGenerator.NextUInt(uint maxValue) => Wrapped.NextUInt(maxValue);
-    //     uint IGenerator.NextUInt(uint minValue, uint maxValue) => Wrapped.NextUInt(minValue, maxValue);
-    //     uint IGenerator.NextUIntExclusiveMaxValue() => Wrapped.NextUInt(uint.MaxValue);
-    //     uint IGenerator.NextUIntInclusiveMaxValue() => Wrapped.NextUInt();
-    //     bool IGenerator.Reset() => false;
-    //     bool IGenerator.Reset(uint seed) => false;
-    //     #endregion
-    // }
+    /// <summary>
+    /// Wraps a ShaiRandom IEnhancedRandom object so it can also be used as a Troschuetz.Random IGenerator.
+    /// </summary>
+    /// <remarks>
+    /// This class implements both IGenerator and IEnhancedRandom.  Any IEnhancedRandom member is implemented by
+    /// simply forwarding to the ShaiRandom generator being wrapped;  all IGenerator methods are explicitly implemented
+    /// and are implemented in terms of IEnhancedRandom methods.
+    /// </remarks>
+    [System.Serializable]
+    public class TRGeneratorWrapper : AbstractRandom, IGenerator
+    {
+        /// <summary>
+        /// The identifying tag here is "TRW", which is a different length to indicate the tag is a wrapper.
+        /// </summary>
+        public override string DefaultTag => "TRW";
+
+        /// <summary>
+        /// The wrapped RNG, which must never be null.
+        /// </summary>
+        public IEnhancedRandom Wrapped { get; set; }
+
+        /// <summary>
+        /// Creates a wrapper around a new FourWheelRandom generator with a random state.
+        /// </summary>
+        public TRGeneratorWrapper() => Wrapped = new FourWheelRandom();
+
+        /// <summary>
+        /// Creates a wrapper around a new FourWheelRandom generator, whose state will be initialized with the given seed.
+        /// </summary>
+        /// <param name="seed">Seed to initialize the new generator with.</param>
+        public TRGeneratorWrapper(ulong seed) => Wrapped = new FourWheelRandom(seed);
+
+        /// <summary>
+        /// Creates a wrapper around the given ShaiRandom generator.
+        /// </summary>
+        /// <param name="wrapped">The ShaiRandom generator to wrap.</param>
+        public TRGeneratorWrapper(IEnhancedRandom wrapped) => Wrapped = wrapped;
+
+        /// <inheritdoc />
+        public override int StateCount => Wrapped.StateCount;
+        /// <inheritdoc />
+        public override bool SupportsReadAccess => Wrapped.SupportsReadAccess;
+        /// <inheritdoc />
+        public override bool SupportsWriteAccess => Wrapped.SupportsWriteAccess;
+        /// <inheritdoc />
+        public override bool SupportsSkip => Wrapped.SupportsSkip;
+        /// <inheritdoc />
+        public override bool SupportsPrevious => Wrapped.SupportsPrevious;
+
+        /// <inheritdoc />
+        public override IEnhancedRandom Copy() => new TRGeneratorWrapper(Wrapped.Copy());
+        /// <inheritdoc />
+        public override double NextDouble() => Wrapped.NextDouble();
+        /// <inheritdoc />
+        public override ulong NextULong() => Wrapped.NextULong();
+        /// <inheritdoc />
+        public override ulong SelectState(int selection) => Wrapped.SelectState(selection);
+        /// <inheritdoc />
+        public override void Seed(ulong seed) => Wrapped.Seed(seed);
+        /// <inheritdoc />
+        public override void SetState(ulong stateA) => Wrapped.SetState(stateA);
+        /// <inheritdoc />
+        public override void SetState(ulong stateA, ulong stateB) => Wrapped.SetState(stateA, stateB);
+        /// <inheritdoc />
+        public override void SetState(ulong stateA, ulong stateB, ulong stateC) => Wrapped.SetState(stateA, stateB, stateC);
+        /// <inheritdoc />
+        public override void SetState(ulong stateA, ulong stateB, ulong stateC, ulong stateD) => Wrapped.SetState(stateA, stateB, stateC, stateD);
+        /// <inheritdoc />
+        public override void SetState(params ulong[] states) => Wrapped.SetState(states);
+        /// <inheritdoc />
+        public override ulong Skip(ulong distance) => Wrapped.Skip(distance);
+        /// <inheritdoc />
+        public override ulong PreviousULong() => Wrapped.PreviousULong();
+        /// <inheritdoc />
+        public override string StringSerialize()
+        {
+            var ser = new StringBuilder(Serializer.GetTag(this));
+            ser.Append('`');
+            ser.Append(Wrapped.StringSerialize());
+            ser.Append('`');
+
+            return ser.ToString();
+        }
+
+        /// <inheritdoc />
+        public override IEnhancedRandom StringDeserialize(ReadOnlySpan<char> data)
+        {
+            Wrapped = Serializer.Deserialize(data[1..]);
+            return this;
+        }
+
+        #region IGenerator explicit implementation
+        bool IGenerator.CanReset => false;
+        uint IGenerator.Seed => 1;
+        int IGenerator.Next() => Wrapped.NextInt(int.MaxValue);
+        int IGenerator.Next(int maxValue) => Wrapped.NextInt(maxValue);
+        int IGenerator.Next(int minValue, int maxValue) => Wrapped.NextInt(minValue, maxValue);
+        bool IGenerator.NextBoolean() => Wrapped.NextBool();
+        void IGenerator.NextBytes(byte[] buffer) => Wrapped.NextBytes(buffer);
+        double IGenerator.NextDouble() => Wrapped.NextDouble();
+        double IGenerator.NextDouble(double maxValue) => Wrapped.NextDouble(maxValue);
+        double IGenerator.NextDouble(double minValue, double maxValue) => Wrapped.NextDouble(minValue, maxValue);
+        int IGenerator.NextInclusiveMaxValue() => (int)Wrapped.NextBits(31);
+        uint IGenerator.NextUInt() => Wrapped.NextUInt(uint.MaxValue);
+        uint IGenerator.NextUInt(uint maxValue) => Wrapped.NextUInt(maxValue);
+        uint IGenerator.NextUInt(uint minValue, uint maxValue) => Wrapped.NextUInt(minValue, maxValue);
+        uint IGenerator.NextUIntExclusiveMaxValue() => Wrapped.NextUInt(uint.MaxValue);
+        uint IGenerator.NextUIntInclusiveMaxValue() => Wrapped.NextUInt();
+        bool IGenerator.Reset() => false;
+        bool IGenerator.Reset(uint seed) => false;
+        #endregion
+    }
 }

--- a/ShaiRandom.TroschuetzCompat/SerializerExtensions.cs
+++ b/ShaiRandom.TroschuetzCompat/SerializerExtensions.cs
@@ -6,68 +6,68 @@ using ShaiRandom.TroschuetzCompat.Generators;
 
 namespace ShaiRandom.TroschuetzCompat
 {
-    // /// <summary>
-    // /// Static class defining methods which allow convenient registration of the standard
-    // /// tags for all generators defined in TroschuetzCompat.
-    // /// </summary>
-    // /// <remarks>
-    // /// These are the same as the <see cref="Serializer.RegisterShaiRandomDefaultTags"/> and similar methods,
-    // /// however these register the generators defined in TroschuetzCompat, rather than the ones defined in
-    // /// ShaiRandom.
-    // /// </remarks>
-    // public static class SerializerExtensions
-    // {
-    //     /// <summary>
-    //     /// Registers the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.TroschuetzCompat.
-    //     /// </summary>
-    //     /// <exception cref="ArgumentException">One of the tags failed to register.</exception>
-    //     /// <remarks>
-    //     /// This function will throw an exception if any of the tags are already registered to their type,
-    //     /// or if any of the tags have already been registered to something else.  For a more tolerant way of setting
-    //     /// tags, see the <see cref="TryRegisterTroschuetzCompatDefaultTags"/> function.
-    //     /// </remarks>
-    //     public static void RegisterTroschuetzCompatDefaultTags()
-    //     {
-    //         foreach (var instance in GetSerializerInstancesForCompatRandomGens())
-    //             Serializer.RegisterTag(instance);
-    //     }
-    //
-    //     /// <summary>
-    //     /// Tries to register the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.TroschuetzCompat.
-    //     /// </summary>
-    //     /// <remarks>
-    //     /// This function will return false if ANY of the tags failed to set; however it will attempt to set tags for
-    //     /// ALL the generators in ShaiRandom.TroschuetzCompat, even if one fails.  If you wish to forcibly set all the
-    //     /// ShaiRandom.TroschuetzCompat generators to be registered to their tag, see the
-    //     /// <see cref="ForceRegisterTroschuetzCompatDefaultTags"/> function.
-    //     /// </remarks>
-    //     public static bool TryRegisterTroschuetzCompatDefaultTags()
-    //     {
-    //         bool allSucceeded = true;
-    //         foreach (var instance in GetSerializerInstancesForCompatRandomGens())
-    //             allSucceeded &= Serializer.TryRegisterTag(instance);
-    //
-    //         return allSucceeded;
-    //     }
-    //
-    //     /// <summary>
-    //     /// Registers the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.TroschuetzCompat, overwriting any
-    //     /// existing registrations for those types and tags.
-    //     /// </summary>
-    //     /// <remarks>
-    //     /// This function will unregister any conflicting tags, and replace them with the default tags, for all
-    //     /// ShaiRandom.TroschuetzCompat implementations.  For a way of setting tags that is more tolerant to existing registrations,
-    //     /// see <see cref="TryRegisterTroschuetzCompatDefaultTags"/>.
-    //     /// </remarks>
-    //     public static void ForceRegisterTroschuetzCompatDefaultTags()
-    //     {
-    //         foreach (var instance in GetSerializerInstancesForCompatRandomGens())
-    //             Serializer.ForceRegisterTag(instance);
-    //     }
-    //
-    //     private static IEnumerable<IEnhancedRandom> GetSerializerInstancesForCompatRandomGens()
-    //     {
-    //         yield return new TRGeneratorWrapper(new DistinctRandom(1UL));
-    //     }
-    // }
+    /// <summary>
+    /// Static class defining methods which allow convenient registration of the standard
+    /// tags for all generators defined in TroschuetzCompat.
+    /// </summary>
+    /// <remarks>
+    /// These are the same as the <see cref="Serializer.RegisterShaiRandomDefaultTags"/> and similar methods,
+    /// however these register the generators defined in TroschuetzCompat, rather than the ones defined in
+    /// ShaiRandom.
+    /// </remarks>
+    public static class SerializerExtensions
+    {
+        /// <summary>
+        /// Registers the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.TroschuetzCompat.
+        /// </summary>
+        /// <exception cref="ArgumentException">One of the tags failed to register.</exception>
+        /// <remarks>
+        /// This function will throw an exception if any of the tags are already registered to their type,
+        /// or if any of the tags have already been registered to something else.  For a more tolerant way of setting
+        /// tags, see the <see cref="TryRegisterTroschuetzCompatDefaultTags"/> function.
+        /// </remarks>
+        public static void RegisterTroschuetzCompatDefaultTags()
+        {
+            foreach (var instance in GetSerializerInstancesForCompatRandomGens())
+                Serializer.RegisterTag(instance);
+        }
+
+        /// <summary>
+        /// Tries to register the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.TroschuetzCompat.
+        /// </summary>
+        /// <remarks>
+        /// This function will return false if ANY of the tags failed to set; however it will attempt to set tags for
+        /// ALL the generators in ShaiRandom.TroschuetzCompat, even if one fails.  If you wish to forcibly set all the
+        /// ShaiRandom.TroschuetzCompat generators to be registered to their tag, see the
+        /// <see cref="ForceRegisterTroschuetzCompatDefaultTags"/> function.
+        /// </remarks>
+        public static bool TryRegisterTroschuetzCompatDefaultTags()
+        {
+            bool allSucceeded = true;
+            foreach (var instance in GetSerializerInstancesForCompatRandomGens())
+                allSucceeded &= Serializer.TryRegisterTag(instance);
+
+            return allSucceeded;
+        }
+
+        /// <summary>
+        /// Registers the DefaultTag for all of the IEnhancedRandom implementations in ShaiRandom.TroschuetzCompat, overwriting any
+        /// existing registrations for those types and tags.
+        /// </summary>
+        /// <remarks>
+        /// This function will unregister any conflicting tags, and replace them with the default tags, for all
+        /// ShaiRandom.TroschuetzCompat implementations.  For a way of setting tags that is more tolerant to existing registrations,
+        /// see <see cref="TryRegisterTroschuetzCompatDefaultTags"/>.
+        /// </remarks>
+        public static void ForceRegisterTroschuetzCompatDefaultTags()
+        {
+            foreach (var instance in GetSerializerInstancesForCompatRandomGens())
+                Serializer.ForceRegisterTag(instance);
+        }
+
+        private static IEnumerable<IEnhancedRandom> GetSerializerInstancesForCompatRandomGens()
+        {
+            yield return new TRGeneratorWrapper(new DistinctRandom(1UL));
+        }
+    }
 }

--- a/ShaiRandom.TroschuetzCompat/ShaiRandom.TroschuetzCompat.csproj
+++ b/ShaiRandom.TroschuetzCompat/ShaiRandom.TroschuetzCompat.csproj
@@ -93,7 +93,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Troschuetz.Random" Version="5.0.1" />
-    <PackageReference Include="ShaiRandom" Version="0.0.1-alpha04" />
+    <PackageReference Include="ShaiRandom" Version="0.0.1-alpha05" />
   </ItemGroup>
 
   <!-- When packing, copy the nuget files to the nuget output directory -->

--- a/ShaiRandom.UnitTests/DataGenerators.cs
+++ b/ShaiRandom.UnitTests/DataGenerators.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using ShaiRandom.Generators;
-//using ShaiRandom.TroschuetzCompat.Generators;
+using ShaiRandom.TroschuetzCompat.Generators;
 using ShaiRandom.Wrappers;
 
 namespace ShaiRandom.UnitTests
@@ -40,7 +40,7 @@ namespace ShaiRandom.UnitTests
                 yield return new ReversingWrapper();
 
                 // ShaiRandom.TroschuetzCompat
-                //yield return new TRGeneratorWrapper();
+                yield return new TRGeneratorWrapper();
             }
         }
     }

--- a/ShaiRandom.UnitTests/TestFramework.cs
+++ b/ShaiRandom.UnitTests/TestFramework.cs
@@ -1,4 +1,4 @@
-﻿//using ShaiRandom.TroschuetzCompat;
+﻿using ShaiRandom.TroschuetzCompat;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
@@ -11,7 +11,7 @@ namespace ShaiRandom.UnitTests
             :base(messageSink)
         {
             Serializer.RegisterShaiRandomDefaultTags();
-            //SerializerExtensions.RegisterTroschuetzCompatDefaultTags();
+            SerializerExtensions.RegisterTroschuetzCompatDefaultTags();
         }
     }
 }


### PR DESCRIPTION
# Changes
- Uncommented all TroschuetzCompat related code
- Changed `TroscheutzCompat` package to depend on ShaiRandom alpha 05.
    - Recommend after stable release of Shai, this be changed to a floating version reference 0.*

# Notes
TroschuetzCompat package will now compile and place a separate NuGet package in the `nuget/` folder, which can be released as per standard.  The unit test project tests the TRGenerator code along with its other test data again.  TroschuetzCompat should now be ready for release.