### PR TITLE
Probability Table Enhancement

### DIFF
--- a/ShaiRandom.TroschuetzCompat/Distributions/TRContinuousDistributionWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Distributions/TRContinuousDistributionWrapper.cs
@@ -1,7 +1,4 @@
-﻿using ShaiRandom.Distributions;
-using Troschuetz.Random;
-
-namespace ShaiRandom.TroschuetzCompat.Distributions
+﻿namespace ShaiRandom.TroschuetzCompat.Distributions
 {
     /// <summary>
     /// Wraps a ShaiRandom IEnhancedContinuousDistribution object so it can also be used as a Troschuetz.Random IContinuousDistribution.

--- a/ShaiRandom.TroschuetzCompat/Distributions/TRDiscreteDistributionWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Distributions/TRDiscreteDistributionWrapper.cs
@@ -1,7 +1,4 @@
-﻿using ShaiRandom.Distributions;
-using Troschuetz.Random;
-
-namespace ShaiRandom.TroschuetzCompat.Distributions
+﻿namespace ShaiRandom.TroschuetzCompat.Distributions
 {
     /// <summary>
     /// Wraps a ShaiRandom IEnhancedDiscreteDistribution object so it can also be used as a Troschuetz.Random IDiscreteDistribution.

--- a/ShaiRandom.TroschuetzCompat/Distributions/TRDistributionWrapper.cs
+++ b/ShaiRandom.TroschuetzCompat/Distributions/TRDistributionWrapper.cs
@@ -1,5 +1,4 @@
-﻿using ShaiRandom.Distributions;
-using ShaiRandom.Generators;
+﻿using ShaiRandom.Generators;
 using ShaiRandom.TroschuetzCompat.Generators;
 using Troschuetz.Random;
 using IDistribution = Troschuetz.Random.IDistribution;
@@ -31,25 +30,25 @@ namespace ShaiRandom.TroschuetzCompat.Distributions
         /// <inheritdoc />
         public IEnhancedRandom Generator => Wrapped.Generator;
 
-        /// <inheritdoc cref="IEnhancedDistribution.Maximum" />
+        /// <inheritdoc cref="IDistribution.Maximum" />
         public double Maximum => Wrapped.Maximum;
 
-        /// <inheritdoc cref="IEnhancedDistribution.Mean" />
+        /// <inheritdoc cref="IDistribution.Mean" />
         public double Mean => Wrapped.Mean;
 
-        /// <inheritdoc cref="IEnhancedDistribution.Median" />
+        /// <inheritdoc cref="IDistribution.Median" />
         public double Median => Wrapped.Median;
 
-        /// <inheritdoc cref="IEnhancedDistribution.Minimum" />
+        /// <inheritdoc cref="IDistribution.Minimum" />
         public double Minimum => Wrapped.Minimum;
 
-        /// <inheritdoc cref="IEnhancedDistribution.Mode" />
+        /// <inheritdoc cref="IDistribution.Mode" />
         public double[] Mode => Wrapped.Mode;
 
-        /// <inheritdoc cref="IEnhancedDistribution.Variance" />
+        /// <inheritdoc cref="IDistribution.Variance" />
         public double Variance => Wrapped.Variance;
 
-        /// <inheritdoc cref="IEnhancedDistribution.NextDouble" />
+        /// <inheritdoc cref="IDistribution.NextDouble" />
         public double NextDouble() => Wrapped.NextDouble();
 
         #region IDistribution Explicit Implementations

--- a/ShaiRandom/Collections/ProbabilityTable.cs
+++ b/ShaiRandom/Collections/ProbabilityTable.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using ShaiRandom.Generators;
 
 namespace ShaiRandom.Collections
@@ -32,81 +33,136 @@ namespace ShaiRandom.Collections
         /// <summary>
         /// Constructs an empty ProbabilityTable. You must call Reset() with some items this can choose from before using this ProbabilityTable.
         /// </summary>
-        public ProbabilityTable() : this(new MizuchiRandom(), new List<(TItem item, double weight)>(0))
+        public ProbabilityTable() : this(new MizuchiRandom(), Array.Empty<(TItem, double)>())
         {
         }
 
         /// <summary>
         /// Constructs a ProbabilityTable that will use the given (item, weight) pairs and an unseeded MizuchiRandom.
         /// </summary>
-        /// <param name="items">An IReadOnlyList of pairs, where the first item of a pair is the TItem to be potentially returned, and the second item is the weight for how much to favor returning that item.</param>
-        public ProbabilityTable(IReadOnlyList<(TItem item, double weight)> items) : this(new MizuchiRandom(), items)
+        /// <param name="items">
+        /// A list of pairs, where the first item of a pair is the TItem to be potentially returned,
+        /// and the second item is the weight for how much to favor returning that item.
+        /// </param>
+        public ProbabilityTable(IEnumerable<(TItem item, double weight)> items) : this(new MizuchiRandom(), items.ToArray())
         {
         }
+
+        /// <summary>
+        /// Constructs a ProbabilityTable that will use the given (item, weight) pairs and an unseeded MizuchiRandom.
+        /// </summary>
+        /// <param name="items">
+        /// An IReadOnlyList of pairs, where the first item of a pair is the TItem to be potentially returned,
+        /// and the second item is the weight for how much to favor returning that item.  The list will NOT be copied,
+        /// and must not be modified after it is passed to this function.
+        /// </param>
+        public ProbabilityTable(ref IReadOnlyList<(TItem item, double weight)> items) : this(new MizuchiRandom(), items)
+        {
+        }
+
+
         /// <summary>
         /// Constructs a ProbabilityTable that will use the given (item, weight) pairs and the given IEnhancedRandom.
         /// </summary>
         /// <param name="random">Any IEnhancedRandom, such as a <see cref="TrimRandom"/> or <see cref="LaserRandom"/>.</param>
-        /// <param name="items">An IReadOnlyList of pairs, where the first item of a pair is the TItem to be potentially returned, and the second item is the weight for how much to favor returning that item.</param>
-        public ProbabilityTable(IEnhancedRandom random, IReadOnlyList<(TItem item, double weight)> items)
-        {
-            Random = random;
-            Reset(items);
-        }
-        /// <summary>
-        /// Constructs a ProbabilityTable that will use the given items and weights as side-by-side sequences of the same length, and an unseeded MizuchiRandom.
-        /// </summary>
-        /// <param name="items">An IReadOnlyList of TItem instances; this should have the same length as weights.</param>
-        /// <param name="weights">An IReadOnlyList of double weights; this should have the same length as items.</param>
-        public ProbabilityTable(IReadOnlyList<TItem> items, IReadOnlyList<double> weights) : this(new MizuchiRandom(), items, weights)
+        /// <param name="items">
+        /// A list of pairs, where the first item of a pair is the TItem to be potentially returned, and the
+        /// second item is the weight for how much to favor returning that item.
+        /// </param>
+        public ProbabilityTable(IEnhancedRandom random, IEnumerable<(TItem item, double weight)> items) : this(random, items.ToArray())
         {
         }
+
         /// <summary>
-        /// Constructs a ProbabilityTable that will use the given items and weights as side-by-side sequences of the same length, and the given IEnhancedRandom.
+        /// Constructs a ProbabilityTable that will use the given (item, weight) pairs and the given IEnhancedRandom.
         /// </summary>
         /// <param name="random">Any IEnhancedRandom, such as a <see cref="TrimRandom"/> or <see cref="LaserRandom"/>.</param>
-        /// <param name="items">An IReadOnlyList of TItem instances; this should have the same length as weights.</param>
-        /// <param name="weights">An IReadOnlyList of double weights; this should have the same length as items.</param>
-        public ProbabilityTable(IEnhancedRandom random, IReadOnlyList<TItem> items, IReadOnlyList<double> weights)
+        /// <param name="items">
+        /// An IReadOnlyList of pairs, where the first item of a pair is the TItem to be potentially returned, and the
+        /// second item is the weight for how much to favor returning that item.  The list will NOT be copied,
+        /// and must not be modified after it is passed to this function.
+        /// </param>
+        public ProbabilityTable(IEnhancedRandom random, ref IReadOnlyList<(TItem item, double weight)> items) : this(random, items)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a ProbabilityTable that will use the given items and weights as side-by-side sequences, and an unseeded MizuchiRandom.
+        /// </summary>
+        /// <remarks>
+        /// If TItem is a reference type, the objects themselves are not copied.  If the two lists given are not the same size,
+        /// items will be paired until the end of one of the lists is reached.
+        /// </remarks>
+        /// <param name="items">A list of TItem instances.</param>
+        /// <param name="weights">A list of double weights.</param>
+        public ProbabilityTable(IEnumerable<TItem> items, IEnumerable<double> weights) : this(new MizuchiRandom(), items, weights)
+        {
+        }
+        /// <summary>
+        /// Constructs a ProbabilityTable that will use the given items and weights as side-by-side sequences, and the given IEnhancedRandom.
+        /// </summary>
+        /// <remarks>
+        /// If TItem is a reference type, the objects themselves are not copied.  If the two lists given are not the same size,
+        /// items will be paired until the end of one of the lists is reached.
+        /// </remarks>
+        /// <param name="random">Any IEnhancedRandom, such as a <see cref="TrimRandom"/> or <see cref="LaserRandom"/>.</param>
+        /// <param name="items">A list of TItem instances.</param>
+        /// <param name="weights">A list of double weights.</param>
+        public ProbabilityTable(IEnhancedRandom random, IEnumerable<TItem> items, IEnumerable<double> weights)
         {
             Random = random;
             Reset(items, weights);
         }
-        /// <summary>
-        /// Resets the ProbabilityTable to use a different group of items and weights, with the items and weights specified in side-by-side IReadOnlyList instances.
-        /// </summary>
-        /// <remarks>
-        /// This does not keep a reference to items or to weights, but does use direct references to the same TItem instances of they are reference types.
-        /// </remarks>
-        /// <param name="items">An IReadOnlyList of TItem instances; this should have the same length as weights.</param>
-        /// <param name="weights">An IReadOnlyList of double weights; this should have the same length as items.</param>
-        /// <exception cref="ArgumentNullException">If items is null or weights is null.</exception>
-        public void Reset(IReadOnlyList<TItem> items, IReadOnlyList<double> weights)
-        {
-            if (items is null) throw new ArgumentNullException(nameof(items));
-            if (weights is null) throw new ArgumentNullException(nameof(weights));
 
-            int used = Math.Min(items.Count, weights.Count);
-            List<(TItem item, double weight)> newItems = new List<(TItem item, double weight)>(used);
-            for (int i = 0; i < used; i++)
-            {
-                newItems.Add((items[i], weights[i]));
-            }
-            Reset(newItems, false);
+        // No deep copy
+        private ProbabilityTable(IEnhancedRandom random, IReadOnlyList<(TItem item, double weight)> items)
+        {
+            Random = random;
+            Reset(items);
         }
+
         /// <summary>
-        /// Resets the ProbabilityTable to use a different group of items and weights, with the items and weights specified as pairs in one IReadOnlyList.
+        /// Resets the ProbabilityTable to use a different group of items and weights, with the items and weights specified in side-by-side lists.
         /// </summary>
         /// <remarks>
-        /// This defensively copies the given IReadOnlyList.
+        /// If TItem is a reference type, the objects themselves will not be copied.  If the two lists given are not the same size,
+        /// items will be paired until the end of one of the lists is reached.
+        /// </remarks>
+        /// <param name="items">A list of TItem instances.</param>
+        /// <param name="weights">An IReadOnlyList of double weights.</param>
+        public void Reset(IEnumerable<TItem> items, IEnumerable<double> weights)
+        {
+            var list = new List<(TItem item, double weight)>();
+
+            using (IEnumerator<TItem> itemsIt = items.GetEnumerator())
+            using (IEnumerator<double> weightsIt = weights.GetEnumerator())
+            {
+                while (itemsIt.MoveNext() && weightsIt.MoveNext())
+                    list.Add((itemsIt.Current, weightsIt.Current));
+            }
+
+            Reset(list);
+        }
+
+        /// <summary>
+        /// Resets the ProbabilityTable to use a different group of items and weights, with the items and weights specified as pairs in one list.
+        /// </summary>
+        /// <param name="items">A list of pairs, where the first item of a pair is the TItem to be potentially returned, and the second item is the weight for how much to favor returning that item.</param>
+        public void Reset(IEnumerable<(TItem item, double weight)> items) => Reset(items.ToArray());
+
+        /// <summary>
+        /// Resets the ProbabilityTable to use a different group of items and weights, with the items and weights specified as pairs in one list.
+        /// </summary>
+        /// <remarks>
+        /// This does NOT copy the given list, and the list must not be changed after it is passed to this function.
         /// </remarks>
         /// <param name="items">An IReadOnlyList of pairs, where the first item of a pair is the TItem to be potentially returned, and the second item is the weight for how much to favor returning that item.</param>
-        public void Reset(IReadOnlyList<(TItem item, double weight)> items) {
-            Reset(items, true);
-        }
-        private void Reset(IReadOnlyList<(TItem item, double weight)> items, bool defensiveCopy)
+        public void Reset(ref IReadOnlyList<(TItem item, double weight)> items) => Reset(items);
+
+        // No defensive copy
+        private void Reset(IReadOnlyList<(TItem item, double weight)> items)
         {
-            Items = defensiveCopy ? new List<(TItem item, double weight)>(items) : items;
+            Items = items;
 
             if (_mixed is null || _mixed.Length != (items.Count << 1))
                 _mixed = new uint[items.Count << 1];
@@ -176,14 +232,15 @@ namespace ShaiRandom.Collections
                 large.RemoveAt(large.Count - 1);
             }
         }
+
         /// <summary>
         /// Gets a randomly-chosen TItem item (obeying the given weights) from the data this stores.
         /// </summary>
         /// <returns>A randomly-chosen TItem item.</returns>
-        /// <exception cref="IndexOutOfRangeException">If this was reset or initialized with an empty list of items.</exception>
+        /// <exception cref="InvalidOperationException">If this was reset or initialized with an empty list of items.</exception>
         public TItem NextItem()
         {
-            if (Items.Count == 0) throw new IndexOutOfRangeException("NextItem() cannot be used if there are no items; use Reset() before calling.");
+            if (Items.Count == 0) throw new InvalidOperationException("NextItem() cannot be used if there are no items; use Reset() before calling.");
             ulong state = Random.NextULong();
             // get a random int (using half the bits of our previously-calculated state) that is less than size
             uint column = (uint)(((ulong)Count * (state & 0xFFFFFFFFUL)) >> 32);

--- a/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
+++ b/ShaiRandom/Distributions/Continuous/KumaraswamyDistribution.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using ShaiRandom.Generators;
 
 namespace ShaiRandom.Distributions.Continuous
@@ -261,6 +262,7 @@ namespace ShaiRandom.Distributions.Continuous
         /// <exception cref="NotSupportedException">
         ///   Thrown if mode is not defined for given distribution with some parameters.
         /// </exception>
+        [SuppressMessage("ReSharper", "CompareOfFloatsByEqualityOperator")]
         public double[] Mode
         {
             get

--- a/ShaiRandom/Distributions/Discrete/CategoricalDistribution.cs
+++ b/ShaiRandom/Distributions/Discrete/CategoricalDistribution.cs
@@ -61,7 +61,7 @@ namespace ShaiRandom.Distributions.Discrete
         /// <summary>
         ///   Stores the cumulative distribution of current normalized weights.
         /// </summary>
-        private double[] _cdf;
+        private double[] _cdf = null!; // Initialized via helper method
 
         /// <summary>
         ///   Stores the unnormalized categorical weights.
@@ -85,6 +85,7 @@ namespace ShaiRandom.Distributions.Discrete
             get { return _weights.ToList(); }
             set
             {
+                // ReSharper disable once SuspiciousParameterNameInArgumentNullException
                 if (value == null) throw new ArgumentNullException(nameof(Weights), ErrorMessages.NullWeights);
                 if (value.Count == 0) throw new ArgumentException(ErrorMessages.EmptyList, nameof(Weights));
                 if (!AreValidWeights(value)) throw new ArgumentOutOfRangeException(nameof(Weights), ErrorMessages.InvalidParams);
@@ -399,7 +400,7 @@ namespace ShaiRandom.Distributions.Discrete
         /// <exception cref="NotSupportedException">
         ///   Thrown if mode is not defined for given distribution with some parameters.
         /// </exception>
-        public double[] Mode { get; private set; }
+        public double[] Mode { get; private set; } = null!;
 
         /// <summary>
         ///   Gets the variance of distributed random numbers.
@@ -504,7 +505,7 @@ namespace ShaiRandom.Distributions.Discrete
         /// <remarks>
         ///   Also remember to change <see cref="UpdateHelpers"/> when changing this method.
         /// </remarks>
-        internal static void SetUp(int weightsCount, IEnumerable<double> weights, out double[] cdf)
+        internal static void SetUp(int weightsCount, IEnumerable<double>? weights, out double[] cdf)
         {
             var weightsList = (weights == null) ? Ones(weightsCount) : weights.ToList();
             var weightsSum = weightsList.Sum(); // It will store the sum of all UNNORMALIZED weights.


### PR DESCRIPTION
# Changes
- Miscellaneous code cleanup (mostly fixing nullable reference warnings, unused using notifications, etc)
- Used some new C# index notation in `ProbabilityTable` to make some array indexes less verbose (shouldn't have a speed penalty)
- Made `Random` and auto-property, since the only addition of the custom property setter was a null-check on set, and null shouldn't be passed to it anyway since the type is non-nullable
    - Allowing null and converting it to `MizuchiRandom` is also possible, however doing so properly would require one additional nullable type annotation; if you prefer this method I can switch to it)
- Modified construction/`Reset` interface in `ProbabilityTable` to accommodate `IEnumerables`, as well as to allow the user to avoid copying of lists/arrays where it is undesirable (see notes)
- Changed `IndexOutOfRangeException` to `InvalidOperationException`, since the definition as given in the C# documentation should fit slightly better

# Notes
Most of the code cleanup changes were minor the primary change in this PR has to do with the `Reset`/constructor interface of `ProbabilityTable`.  The following summarizes the changes/intent:

First, any function or constructor that previously took a list of `(TItem, double)` tuples, now has two versions; :
```cs
public void Reset(IEnumerable<(TItem item, double weight)> items)
{
    // Call ToArray on items, and pass it to another Reset overload such that the newly created list
   // is used without making a copy
}

public void Reset(ref IReadOnlyList<(TItem item, double weight)> items)
{
  // Use the given list directly, without making a copy of it.
}
```

The idea here is to implement an interface in line with these goals:
1. Ensure a `ProbabilityTable` structure can be easily constructed from whatever data the user has available (by supporting `IEnumerable`)
2. Ensure the user is not _forced_ to copy their data unnecessarily
3. Ensure the user's list _will_ be copied unless they explicitly specify that they do not want to copy (to avoid subtle bugs), while remaining as syntactically succinct as reasonably possible for a user.

The concept is based upon the following pieces of information:
1. `List` and arrays both implement `IEnumerable`, and `IEnumerable` supports virtually every use case involving a collection, between direct implementations and generators via `yield return`.
2. Arrays and lists both implement `IReadOnlyList`
3. Parameters marked with `ref` keyword must be _explicitly_ marked as ref when they are passed (the user cannot "accidentally" pass something as `ref`).

In practice, the idea looks something like this:

```cs
public class UsersSuperComplexItem
{
    public string Name;
    public double Probability;
    // Lots of other fields
}

var complexExample = new List<UsersSuperComplexItem>() { /* Put a bunch of items here */ };
var simpleExample = new List<(string item, double weight)>() { /* Put a bunch of items here */ };

var probTable = new ProbabilityTable();
// I can do this, and the list will be copied; Because the IEnumerable overload is called
probTable.Reset(simpleExample);

// But I don't want to copy the list, I'd rather just use the one I have... Ok, I can do this.
// But i'll never do it accidentally, unless I somehow add the 'ref' keyword to the front
// accidentally?
probTable.Reset(ref simpleExample);

// Complex data structure isn't an issue either, I can even use LINQ, if I dare
probTable.Reset(complexExample.Select(i => (i.Name, i.Probability)));
```

One thing to note; although I've seen the `ref` keyword used for stuff like this in a few places, this is this is not really the "intended" use of the ref keyword, per-se.  What `ref` really means, is, "pass a non-const pointer".  In this case, it's being used on a IReadOnlyList (already a reference type); so really what we're getting is a pointer to a pointer here.  That much said, one can argue that this isn't really a problem, for a few reasons:
1. Resets don't happen very often relative to `NextItems`, more than likely, so the extra overhead of a pointer dereference as it's passed along is not at all likely to be noticeable
2. The compiler _may_ (or may not) optimize out the extra pointer anyway, since it's just immediately copied.

Again, the reason it's used this way here is to _require_ the user to explicitly state when they are expecting to use data as-is with no copy by placing the ref keyword before it.  If you don't prefer this method, it is also possible to accomplish something similar using a boolean value like was originally in the code; however because lists, for example, convert implicitly to both IReadOnlyList and IEnumerable, using such a method may result in it being somewhat ambiguous what overload is being called if you're not quite careful with how the interface is set up.  Functionally, however, either is possible and I can adapt the PR to either preference.

The other change, is that functions taking two separate lists, one of items and one of weights, now take `IEnumerables` instead of `IReadOnlyLists`.  This fits the paradigm for the other overloads, since in any case these functions _must_ result in a copy of the data (which is precisely what all the `IEnumerable` overloads result in.

It is worthy of note that the act of iterating over `IEnumerables` compared to `IReadOnlyLists` _may_ involve more runtime overhead/performance impact, however in this case I believe it should be minor, for mostly reasons mentioned above:
1. Resets may not actually occur that often
2. The Reset function itself does a fair amount of allocating memory (lists, arrays, etc); so since the `Reset` function will take non-trivial time, the overhead of `IEnumerable` should not be noticable here

Feel free to let me know what you think and if you want any changes.