### PR TITLE
Added Unit Tests and Fixed Serialization

### DIFF
--- a/ShaiRandom.TroschuetzCompat/ShaiRandom.TroschuetzCompat.csproj
+++ b/ShaiRandom.TroschuetzCompat/ShaiRandom.TroschuetzCompat.csproj
@@ -54,6 +54,9 @@
 
     <!-- Generate documentation files for all configurations since Debug and Release are published to NuGet. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Since we explicitly support .NET 5.0 as one (of many) targets, suppress the warning about .NET 5 being at end of life. -->
+    <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <!-- Define trace constant for debug builds. -->
@@ -87,7 +90,7 @@
 
   <!-- Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ShaiRandom.UnitTests/DataGenerators.cs
+++ b/ShaiRandom.UnitTests/DataGenerators.cs
@@ -23,16 +23,17 @@ namespace ShaiRandom.UnitTests
             yield return new DistinctRandom();
             yield return new FourWheelRandom();
             yield return new LaserRandom();
+            yield return new MaxRandom();
+            yield return new MinRandom();
             yield return new MizuchiRandom();
             yield return new RomuTrioRandom();
+            yield return new ScruffRandom();
             yield return new StrangerRandom();
             yield return new TricycleRandom();
-            yield return new Xoshiro256StarStarRandom();
             yield return new TrimRandom();
             yield return new WhiskerRandom();
-            yield return new ScruffRandom();
-            yield return new MinRandom();
-            yield return new MaxRandom();
+            yield return new Xorshift128PlusRandom();
+            yield return new Xoshiro256StarStarRandom();
 
             if (includeWrappers)
             {

--- a/ShaiRandom.UnitTests/PreviousTests.cs
+++ b/ShaiRandom.UnitTests/PreviousTests.cs
@@ -21,9 +21,8 @@ namespace ShaiRandom.UnitTests
             for (int i = 0; i < 100; i++)
                 forward.Add(gen.NextULong());
 
-            // Advancing one extra step is needed so when we go back, it gives us the last element added to forward.
-            gen.NextULong();
             forward.Reverse();
+
             for (int i = 0; i < 100; i++)
                 Assert.Equal(forward[i], gen.PreviousULong());
         }

--- a/ShaiRandom.UnitTests/PreviousTests.cs
+++ b/ShaiRandom.UnitTests/PreviousTests.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using ShaiRandom.Generators;
 using Xunit;
+using XUnit.ValueTuples;
 
 namespace ShaiRandom.UnitTests
 {
@@ -10,25 +11,21 @@ namespace ShaiRandom.UnitTests
     /// </summary>
     public class PreviousTests
     {
-        [Fact]
-        public void PreviousMatchesTest()
+        public static readonly IEnumerable<IEnhancedRandom> Generators = DataGenerators.CreateGenerators(true).Where(g => g.SupportsPrevious);
+
+        [Theory]
+        [MemberDataEnumerable(nameof(Generators))]
+        public void PreviousMatchesTest(IEnhancedRandom gen)
         {
-            IEnhancedRandom[] generators = DataGenerators.CreateGenerators(true).Where(g => g.SupportsPrevious).ToArray();
-            foreach (var gen in generators)
-            {
-                List<ulong> forward = new List<ulong>(100);
-                for (int i = 0; i < 100; i++)
-                {
-                    forward.Add(gen.NextULong());
-                }
-                // Advancing one extra step is needed so when we go back, it gives us the last element added to forward.
-                gen.NextULong();
-                forward.Reverse();
-                for (int i = 0; i < 100; i++)
-                {
-                    Assert.Equal(forward[i], gen.PreviousULong());
-                }
-            }
+            List<ulong> forward = new List<ulong>(100);
+            for (int i = 0; i < 100; i++)
+                forward.Add(gen.NextULong());
+
+            // Advancing one extra step is needed so when we go back, it gives us the last element added to forward.
+            gen.NextULong();
+            forward.Reverse();
+            for (int i = 0; i < 100; i++)
+                Assert.Equal(forward[i], gen.PreviousULong());
         }
     }
 }

--- a/ShaiRandom.UnitTests/ShaiRandom.UnitTests.csproj
+++ b/ShaiRandom.UnitTests/ShaiRandom.UnitTests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0">
 	  <PrivateAssets>all</PrivateAssets>
 	</PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/ShaiRandom/Serializer.cs
+++ b/ShaiRandom/Serializer.cs
@@ -310,9 +310,12 @@ namespace ShaiRandom
             yield return MinRandom.Instance;
             yield return new MizuchiRandom(1UL, 1UL);
             yield return new RomuTrioRandom(1UL, 1UL, 1UL);
+            yield return new ScruffRandom(1UL, 1UL, 1UL, 1UL);
             yield return new StrangerRandom(1UL, 1UL, 1UL, 1UL);
             yield return new TricycleRandom(1UL, 1UL, 1UL);
             yield return new TrimRandom(1UL, 1UL, 1UL, 1UL);
+            yield return new WhiskerRandom(1UL, 1UL, 1UL, 1UL);
+            yield return new Xorshift128PlusRandom(1UL, 1UL);
             yield return new Xoshiro256StarStarRandom(1UL, 1UL, 1UL, 1UL);
 
             // Wrappers

--- a/ShaiRandom/ShaiRandom.csproj
+++ b/ShaiRandom/ShaiRandom.csproj
@@ -49,6 +49,9 @@
 
     <!-- Generate documentation files for all configurations since Debug and Release are published to NuGet. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+    <!-- Since we explicitly support .NET 5.0 as one (of many) targets, suppress the warning about .NET 5 being at end of life. -->
+    <CheckEolTargetFramework Condition="$(TargetFramework.StartsWith('net5.0')) == true">false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <!-- Define trace constant for debug builds. -->


### PR DESCRIPTION
Here I've simply added the new generators (Whiskers and Scruff) to the unit test data so they participate in the test cases.  In the process, I discovered three things:

1. Serialization was broken because the generators weren't registered in the default tag registration like the other built-in generators are.  This is fixed in this PR.

2. `PreviousULong()` was testing for old behavior; the test is modified, and now all generators except for `MinRandom`, `MaxRandom`, and the new generators fail.  I refactored the `PreviousTests` file to use theories so the individual RNGs are easier to debug, but left the tests broken as I am assuming you have a fix from Juniper that you can just port over.

3. `Xorshift128PlusRandom` was also missing from serialization and the unit tests; I fixed this as well.

Additionally, there were several compiler warnings stemming from out-of-date analyzer package references in the unit test and TroschuetzCompat package; I updated those.  I also suppressed the compiler warning that you get when compiling with .NET 7 or above stating .NET 5 is end of life, since you're explicitly targeting it as a multi-target.