### PR TITLE
Gap Shuffler

### DIFF
--- a/ShaiRandom.PerformanceTests/GapShuffleBenchmarks.cs
+++ b/ShaiRandom.PerformanceTests/GapShuffleBenchmarks.cs
@@ -1,0 +1,251 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using JetBrains.Annotations;
+using ShaiRandom.Generators;
+
+namespace ShaiRandom.PerformanceTests
+{
+    public static class GapShuffleAlternateImplementations
+    {
+        public static IEnumerable<int> GapShuffleYieldReturn(this IEnhancedRandom rng, IEnumerable<int> items)
+        {
+            IList<int> list = items.ToArray();
+            rng.Shuffle(list);
+
+            int index = 0;
+
+            while (true)
+            {
+                int size = list.Count; // In case size changes while we're iterating
+                if(size == 1)
+                    yield return list[0];
+
+                if(index >= size)
+                {
+                    int n = size - 1;
+                    int swapWith;
+                    for (int i = n; i > 1; i--) {
+                        swapWith = rng.NextInt(i);
+                        (list[i - 1], list[swapWith]) = (list[swapWith], list[i - 1]);
+                    }
+                    swapWith = 1 + rng.NextInt(n);
+                    (list[n], list[swapWith]) = (list[swapWith], list[n]);
+                    index = 0;
+                }
+
+                yield return list[index++];
+            }
+            // ReSharper disable once IteratorNeverReturns
+        }
+
+        public static IEnumerable<int> GapShuffleInPlaceYieldReturn(this IEnhancedRandom rng, IList<int> list)
+        {
+            rng.Shuffle(list);
+
+            int index = 0;
+
+            while (true)
+            {
+                int size = list.Count; // In case size changes while we're iterating
+                if(size == 1)
+                    yield return list[0];
+
+                if(index >= size)
+                {
+                    int n = size - 1;
+                    int swapWith;
+                    for (int i = n; i > 1; i--) {
+                        swapWith = rng.NextInt(i);
+                        (list[i - 1], list[swapWith]) = (list[swapWith], list[i - 1]);
+                    }
+                    swapWith = 1 + rng.NextInt(n);
+                    (list[n], list[swapWith]) = (list[swapWith], list[n]);
+                    index = 0;
+                }
+
+                yield return list[index++];
+            }
+            // ReSharper disable once IteratorNeverReturns
+        }
+    }
+    public class GapShuffleBenchmarks
+    {
+        [UsedImplicitly]
+        [Params(10, 50, 100, 500)]
+        public int Size;
+
+        private int[] _numbers = null!;
+        private int[] _inPlaceNumbers = null!;
+        private IEnhancedRandom _rng = null!;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _numbers = new int[Size];
+            _inPlaceNumbers = new int[Size];
+
+            for (int i = 0; i < Size; i++)
+            {
+                _numbers[i] = i + 1;
+                _inPlaceNumbers[i] = i + 1;
+            }
+
+            _rng = new MizuchiRandom(1);
+            _rng.Shuffle(_numbers);
+            _rng.Shuffle(_inPlaceNumbers);
+        }
+
+        [Benchmark]
+        public int ShaiRandomForeach()
+        {
+            int sum = 0;
+            int take = 0;
+            // Don't use .Take(Size) here to avoid boxing
+            foreach (var num in _rng.GapShuffle(_numbers))
+            {
+                sum += num;
+                take++;
+                if (take >= Size) break;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ShaiRandomForeachInPlace()
+        {
+            int sum = 0;
+            int take = 0;
+            // Don't use .Take(Size) here to avoid boxing
+            foreach (var num in _rng.GapShuffleInPlace(_inPlaceNumbers))
+            {
+                sum += num;
+                take++;
+                if (take >= Size) break;
+            }
+
+            return sum;
+        }
+
+        // Include these because .Take would be a very common use case, and would require boxing
+        [Benchmark]
+        public int ShaiRandomForeachTake()
+        {
+            int sum = 0;
+            foreach (var num in _rng.GapShuffle(_numbers).Take(Size))
+                sum += num;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ShaiRandomForeachInPlaceTake()
+        {
+            int sum = 0;
+            foreach (var num in _rng.GapShuffleInPlace(_inPlaceNumbers).Take(Size))
+                sum += num;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int YieldReturnForeach()
+        {
+            int sum = 0;
+            int take = 0;
+            foreach (var num in _rng.GapShuffleYieldReturn(_numbers))
+            {
+                sum += num;
+                take++;
+                if (take >= Size) break;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int YieldReturnForeachInPlace()
+        {
+            int sum = 0;
+            int take = 0;
+            foreach (var num in _rng.GapShuffleInPlaceYieldReturn(_inPlaceNumbers))
+            {
+                sum += num;
+                take++;
+                if (take >= Size) break;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int YieldReturnForeachTake()
+        {
+            int sum = 0;
+            foreach (var num in _rng.GapShuffleYieldReturn(_numbers).Take(Size))
+                sum += num;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int YieldReturnForeachInPlaceTake()
+        {
+            int sum = 0;
+            foreach (var num in _rng.GapShuffleInPlaceYieldReturn(_inPlaceNumbers).Take(Size))
+                sum += num;
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ShaiRandomLinq()
+            => _rng.GapShuffle(_numbers).Take(Size).Sum();
+
+        [Benchmark]
+        public int ShaiRandomLinqInPlace()
+            => _rng.GapShuffleInPlace(_inPlaceNumbers).Take(Size).Sum();
+
+        [Benchmark]
+        public int YieldReturnLinq()
+            => _rng.GapShuffleYieldReturn(_numbers).Take(Size).Sum();
+
+        [Benchmark]
+        public int YieldReturnLinqInPlace()
+            => _rng.GapShuffleInPlaceYieldReturn(_inPlaceNumbers).Take(Size).Sum();
+
+        // We could also just use .Take(x) here since it's already boxed, but we'll avoid it just for grins
+        [Benchmark]
+        public int ShaiRandomIEnumerable()
+        {
+            int sum = 0;
+            IEnumerable<int> enumerable = _rng.GapShuffle(_numbers);
+            int take = 0;
+            foreach (var num in enumerable)
+            {
+                sum += num;
+                take++;
+                if (take >= Size) break;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ShaiRandomIEnumerableInPlace()
+        {
+            int sum = 0;
+            IEnumerable<int> enumerable = _rng.GapShuffleInPlace(_inPlaceNumbers);
+            int take = 0;
+            foreach (var num in enumerable)
+            {
+                sum += num;
+                take++;
+                if (take >= Size) break;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/ShaiRandom.PerformanceTests/GapShuffleBenchmarks.cs
+++ b/ShaiRandom.PerformanceTests/GapShuffleBenchmarks.cs
@@ -102,7 +102,7 @@ namespace ShaiRandom.PerformanceTests
             int sum = 0;
             int take = 0;
             // Don't use .Take(Size) here to avoid boxing
-            foreach (var num in _rng.GapShuffle(_numbers))
+            foreach (var num in _rng.GapShuffler(_numbers))
             {
                 sum += num;
                 take++;
@@ -118,7 +118,7 @@ namespace ShaiRandom.PerformanceTests
             int sum = 0;
             int take = 0;
             // Don't use .Take(Size) here to avoid boxing
-            foreach (var num in _rng.GapShuffleInPlace(_inPlaceNumbers))
+            foreach (var num in _rng.InPlaceGapShuffler(_inPlaceNumbers))
             {
                 sum += num;
                 take++;
@@ -133,7 +133,7 @@ namespace ShaiRandom.PerformanceTests
         public int ShaiRandomForeachTake()
         {
             int sum = 0;
-            foreach (var num in _rng.GapShuffle(_numbers).Take(Size))
+            foreach (var num in _rng.GapShuffler(_numbers).Take(Size))
                 sum += num;
 
             return sum;
@@ -143,7 +143,7 @@ namespace ShaiRandom.PerformanceTests
         public int ShaiRandomForeachInPlaceTake()
         {
             int sum = 0;
-            foreach (var num in _rng.GapShuffleInPlace(_inPlaceNumbers).Take(Size))
+            foreach (var num in _rng.InPlaceGapShuffler(_inPlaceNumbers).Take(Size))
                 sum += num;
 
             return sum;
@@ -201,11 +201,11 @@ namespace ShaiRandom.PerformanceTests
 
         [Benchmark]
         public int ShaiRandomLinq()
-            => _rng.GapShuffle(_numbers).Take(Size).Sum();
+            => _rng.GapShuffler(_numbers).Take(Size).Sum();
 
         [Benchmark]
         public int ShaiRandomLinqInPlace()
-            => _rng.GapShuffleInPlace(_inPlaceNumbers).Take(Size).Sum();
+            => _rng.InPlaceGapShuffler(_inPlaceNumbers).Take(Size).Sum();
 
         [Benchmark]
         public int YieldReturnLinq()
@@ -220,7 +220,7 @@ namespace ShaiRandom.PerformanceTests
         public int ShaiRandomIEnumerable()
         {
             int sum = 0;
-            IEnumerable<int> enumerable = _rng.GapShuffle(_numbers);
+            IEnumerable<int> enumerable = _rng.GapShuffler(_numbers);
             int take = 0;
             foreach (var num in enumerable)
             {
@@ -236,7 +236,7 @@ namespace ShaiRandom.PerformanceTests
         public int ShaiRandomIEnumerableInPlace()
         {
             int sum = 0;
-            IEnumerable<int> enumerable = _rng.GapShuffleInPlace(_inPlaceNumbers);
+            IEnumerable<int> enumerable = _rng.InPlaceGapShuffler(_inPlaceNumbers);
             int take = 0;
             foreach (var num in enumerable)
             {

--- a/ShaiRandom.UnitTests/GapShufflerTests.cs
+++ b/ShaiRandom.UnitTests/GapShufflerTests.cs
@@ -19,7 +19,7 @@ namespace ShaiRandom.UnitTests
         public void GapShuffle()
         {
             var list = new[] { 1, 2, 3, 4, 5 };
-            var shuffler = _rng.GapShuffle(list);
+            var shuffler = _rng.GapShuffler(list);
 
             var shuffled = shuffler.Take(10).ToArray();
             Assert.NotEqual(list, shuffled[..5]);
@@ -31,7 +31,7 @@ namespace ShaiRandom.UnitTests
         {
             var originalList = new[] { 1, 2, 3, 4, 5 };
             var list = new[] { 1, 2, 3, 4, 5 };
-            var shuffler = _rng.GapShuffleInPlace(list);
+            var shuffler = _rng.InPlaceGapShuffler(list);
 
             var shuffled = shuffler.Take(10).ToArray();
             Assert.NotEqual(originalList, shuffled[..5]);

--- a/ShaiRandom.UnitTests/GapShufflerTests.cs
+++ b/ShaiRandom.UnitTests/GapShufflerTests.cs
@@ -2,123 +2,130 @@
 using System.Linq;
 using ShaiRandom.Generators;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace ShaiRandom.UnitTests
 {
     public class GapShufflerTests
     {
-        private readonly ITestOutputHelper _output;
-        private readonly IEnhancedRandom _rng;
-
-        public GapShufflerTests(ITestOutputHelper output)
-        {
-            _output = output;
-            _rng = new MizuchiRandom(1);
-        }
         [Fact]
         public void GapShuffleIEnumerable()
         {
+            var rng = new MizuchiRandom(1);
+
             var originalList = new[] { 1, 2, 3, 4, 5 };
             var list = new[] { 1, 2, 3, 4, 5 };
-            var shuffler = _rng.GapShuffler(list);
+            var shuffler = rng.GapShuffler(list);
 
             var shuffled = shuffler.Take(10).ToArray();
-            var halves = new[] { shuffled[..5], shuffled[5..] };
-            foreach (var half in halves)
-            {
-                // Each set of 5 contains each element of the original precisely once
-                Assert.Equal(list.ToHashSet(), half.ToHashSet());
+            CheckResult(originalList, list, shuffled, false);
 
-                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
-                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
-                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
-                // to the original one after one set of all of its elements or some such.
-                Assert.NotEqual(list, half);
-            }
-
-            // Ensure the original list was not modified (non in-place versions should copy)
-            Assert.Equal(originalList, list);
+            shuffled = GetShuffledWithNext(shuffler);
+            CheckResult(originalList, list, shuffled, false);
         }
 
         [Fact]
         public void GapShuffleSpan()
         {
+            var rng = new MizuchiRandom(1);
+
             var originalList = new[] { 1, 2, 3, 4, 5 };
             var list = new[] { 1, 2, 3, 4, 5 };
-            var shuffler = _rng.GapShuffler<int>(list.AsSpan());
+            var shuffler = rng.GapShuffler<int>(list.AsSpan());
 
             var shuffled = shuffler.Take(10).ToArray();
-            var halves = new[] { shuffled[..5], shuffled[5..] };
-            foreach (var half in halves)
-            {
-                // Each set of 5 contains each element of the original precisely once
-                Assert.Equal(list.ToHashSet(), half.ToHashSet());
+            CheckResult(originalList, list, shuffled, false);
 
-                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
-                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
-                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
-                // to the original one after one set of all of its elements or some such.
-                Assert.NotEqual(list, half);
-            }
-
-            // Ensure the original list was not modified (non in-place versions should copy)
-            Assert.Equal(originalList, list);
+            shuffled = GetShuffledWithNext(shuffler);
+            CheckResult(originalList, list, shuffled, false);
         }
 
         [Fact]
         public void GapShuffleMemory()
         {
+            var rng = new MizuchiRandom(1);
+
             var originalList = new[] { 1, 2, 3, 4, 5 };
             var list = new[] { 1, 2, 3, 4, 5 };
-            var shuffler = _rng.GapShuffler<int>(list.AsMemory());
+            var shuffler = rng.GapShuffler<int>(list.AsMemory());
 
             var shuffled = shuffler.Take(10).ToArray();
-            var halves = new[] { shuffled[..5], shuffled[5..] };
-            foreach (var half in halves)
-            {
-                // Each set of 5 contains each element of the original precisely once
-                Assert.Equal(list.ToHashSet(), half.ToHashSet());
+            CheckResult(originalList, list, shuffled, false);
 
-                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
-                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
-                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
-                // to the original one after one set of all of its elements or some such.
-                Assert.NotEqual(list, half);
-            }
-
-            // Ensure the original list was not modified (non in-place versions should copy)
-            Assert.Equal(originalList, list);
+            shuffled = GetShuffledWithNext(shuffler);
+            CheckResult(originalList, list, shuffled, false);
         }
 
         [Fact]
-        public void GapShuffleInPlace()
+        public void GapShuffleInPlaceIList()
         {
+            var rng = new MizuchiRandom(1);
+
             var originalList = new[] { 1, 2, 3, 4, 5 };
             var list = new[] { 1, 2, 3, 4, 5 };
-            var shuffler = _rng.InPlaceGapShuffler(list);
+            var shuffler = rng.InPlaceGapShuffler(list);
 
             var shuffled = shuffler.Take(10).ToArray();
-            var halves = new[] { shuffled[..5], shuffled[5..] };
-            foreach (var half in halves)
-            {
-                // Each set of 5 contains each element of the original precisely once
-                Assert.Equal(originalList.ToHashSet(), half.ToHashSet());
-
-                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
-                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
-                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
-                // to the original one after one set of all of its elements or some such.
-                Assert.NotEqual(originalList, half);
-            }
-
-            // We'll also check that the original list is modified.  Again, this is not _technically_ enforced by the algorithm,
-            // but is guaranteed to happen with the seed we chose for this test, and ensures that the implementation
-            // is shuffling in-place.
-            Assert.NotEqual(originalList, list);
+            CheckResult(originalList, list, shuffled, true);
         }
 
-        private void CheckResult(int[] originalList, int[] currentList, int[] enumerableToArray, bool inPlace)
+        [Fact]
+        public void GapShuffleInPlaceNextIList()
+        {
+            var rng = new MizuchiRandom(1);
+
+            var originalList = new[] { 1, 2, 3, 4, 5 };
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = rng.InPlaceGapShuffler(list);
+
+            var shuffled = GetShuffledWithNext(shuffler);
+            CheckResult(originalList, list, shuffled, true);
+        }
+
+        [Fact]
+        public void GapShuffleInPlaceMemory()
+        {
+            var rng = new MizuchiRandom(1);
+
+            var originalList = new[] { 1, 2, 3, 4, 5 };
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = rng.InPlaceGapShuffler(list.AsMemory());
+
+            var shuffled = shuffler.Take(10).ToArray();
+            CheckResult(originalList, list, shuffled, true);
+        }
+
+        [Fact]
+        public void GapShuffleInPlaceNextMemory()
+        {
+            var rng = new MizuchiRandom(1);
+
+            var originalList = new[] { 1, 2, 3, 4, 5 };
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = rng.InPlaceGapShuffler(list.AsMemory());
+
+            var shuffled = GetShuffledWithNext(shuffler);
+            CheckResult(originalList, list, shuffled, true);
+        }
+
+        private static int[] GetShuffledWithNext(GapShufflerEnumerator<int> shuffler)
+        {
+            var array = new int[10];
+            for (int i = 0; i < array.Length; i++)
+                array[i] = shuffler.Next();
+
+            return array;
+        }
+
+        private static int[] GetShuffledWithNext(GapShufflerInPlaceMemoryEnumerator<int> shuffler)
+        {
+            var array = new int[10];
+            for (int i = 0; i < array.Length; i++)
+                array[i] = shuffler.Next();
+
+            return array;
+        }
+
+        private static void CheckResult(int[] originalList, int[] currentList, int[] enumerableToArray, bool inPlace)
         {
             // Only required for how we test, not for the algorithm itself
             Assert.Equal(originalList.Length * 2, enumerableToArray.Length);

--- a/ShaiRandom.UnitTests/GapShufflerTests.cs
+++ b/ShaiRandom.UnitTests/GapShufflerTests.cs
@@ -1,0 +1,45 @@
+﻿using System.Linq;
+using ShaiRandom.Generators;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ShaiRandom.UnitTests
+{
+    public class GapShufflerTests
+    {
+        private readonly ITestOutputHelper _output;
+        private readonly IEnhancedRandom _rng;
+
+        public GapShufflerTests(ITestOutputHelper output)
+        {
+            _output = output;
+            _rng = new MizuchiRandom(1);
+        }
+        [Fact]
+        public void GapShuffle()
+        {
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = _rng.GapShuffle(list);
+
+            var shuffled = shuffler.Take(10).ToArray();
+            Assert.NotEqual(list, shuffled[..5]);
+            Assert.NotEqual(list, shuffled[5..]);
+        }
+
+        [Fact]
+        public void GapShuffleInPlace()
+        {
+            var originalList = new[] { 1, 2, 3, 4, 5 };
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = _rng.GapShuffleInPlace(list);
+
+            var shuffled = shuffler.Take(10).ToArray();
+            Assert.NotEqual(originalList, shuffled[..5]);
+            Assert.NotEqual(originalList, shuffled[5..]);
+
+            // Original list was modified
+            Assert.NotEqual(originalList, list);
+            Assert.NotEqual(originalList, shuffled);
+        }
+    }
+}

--- a/ShaiRandom.UnitTests/GapShufflerTests.cs
+++ b/ShaiRandom.UnitTests/GapShufflerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using ShaiRandom.Generators;
 using Xunit;
 using Xunit.Abstractions;
@@ -16,14 +17,78 @@ namespace ShaiRandom.UnitTests
             _rng = new MizuchiRandom(1);
         }
         [Fact]
-        public void GapShuffle()
+        public void GapShuffleIEnumerable()
         {
+            var originalList = new[] { 1, 2, 3, 4, 5 };
             var list = new[] { 1, 2, 3, 4, 5 };
             var shuffler = _rng.GapShuffler(list);
 
             var shuffled = shuffler.Take(10).ToArray();
-            Assert.NotEqual(list, shuffled[..5]);
-            Assert.NotEqual(list, shuffled[5..]);
+            var halves = new[] { shuffled[..5], shuffled[5..] };
+            foreach (var half in halves)
+            {
+                // Each set of 5 contains each element of the original precisely once
+                Assert.Equal(list.ToHashSet(), half.ToHashSet());
+
+                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
+                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
+                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
+                // to the original one after one set of all of its elements or some such.
+                Assert.NotEqual(list, half);
+            }
+
+            // Ensure the original list was not modified (non in-place versions should copy)
+            Assert.Equal(originalList, list);
+        }
+
+        [Fact]
+        public void GapShuffleSpan()
+        {
+            var originalList = new[] { 1, 2, 3, 4, 5 };
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = _rng.GapShuffler<int>(list.AsSpan());
+
+            var shuffled = shuffler.Take(10).ToArray();
+            var halves = new[] { shuffled[..5], shuffled[5..] };
+            foreach (var half in halves)
+            {
+                // Each set of 5 contains each element of the original precisely once
+                Assert.Equal(list.ToHashSet(), half.ToHashSet());
+
+                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
+                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
+                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
+                // to the original one after one set of all of its elements or some such.
+                Assert.NotEqual(list, half);
+            }
+
+            // Ensure the original list was not modified (non in-place versions should copy)
+            Assert.Equal(originalList, list);
+        }
+
+        [Fact]
+        public void GapShuffleMemory()
+        {
+            var originalList = new[] { 1, 2, 3, 4, 5 };
+            var list = new[] { 1, 2, 3, 4, 5 };
+            var shuffler = _rng.GapShuffler<int>(list.AsMemory());
+
+            var shuffled = shuffler.Take(10).ToArray();
+            var halves = new[] { shuffled[..5], shuffled[5..] };
+            foreach (var half in halves)
+            {
+                // Each set of 5 contains each element of the original precisely once
+                Assert.Equal(list.ToHashSet(), half.ToHashSet());
+
+                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
+                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
+                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
+                // to the original one after one set of all of its elements or some such.
+                Assert.NotEqual(list, half);
+            }
+
+            // Ensure the original list was not modified (non in-place versions should copy)
+            Assert.Equal(originalList, list);
         }
 
         [Fact]
@@ -34,12 +99,51 @@ namespace ShaiRandom.UnitTests
             var shuffler = _rng.InPlaceGapShuffler(list);
 
             var shuffled = shuffler.Take(10).ToArray();
-            Assert.NotEqual(originalList, shuffled[..5]);
-            Assert.NotEqual(originalList, shuffled[5..]);
+            var halves = new[] { shuffled[..5], shuffled[5..] };
+            foreach (var half in halves)
+            {
+                // Each set of 5 contains each element of the original precisely once
+                Assert.Equal(originalList.ToHashSet(), half.ToHashSet());
 
-            // Original list was modified
+                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
+                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
+                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
+                // to the original one after one set of all of its elements or some such.
+                Assert.NotEqual(originalList, half);
+            }
+
+            // We'll also check that the original list is modified.  Again, this is not _technically_ enforced by the algorithm,
+            // but is guaranteed to happen with the seed we chose for this test, and ensures that the implementation
+            // is shuffling in-place.
             Assert.NotEqual(originalList, list);
-            Assert.NotEqual(originalList, shuffled);
+        }
+
+        private void CheckResult(int[] originalList, int[] currentList, int[] enumerableToArray, bool inPlace)
+        {
+            // Only required for how we test, not for the algorithm itself
+            Assert.Equal(originalList.Length * 2, enumerableToArray.Length);
+
+            // Split into two halves, each of which should contain each element of the original list exactly once
+            var halves = new[] { enumerableToArray[..5], enumerableToArray[5..] };
+            foreach (var half in halves)
+            {
+                // Each set of 5 contains each element of the original precisely once
+                Assert.Equal(originalList.ToHashSet(), half.ToHashSet());
+
+                // No set is the original list.  This is not _technically_ enforced by the algorithm, but it's
+                // highly unlikely to happen by chance (and won't happen with the particular RNG seed we're using).
+                // It is useful to check this to ensure all streams are randomized, to avoid bugs like the list reverting
+                // to the original one after one set of all of its elements or some such.
+                Assert.NotEqual(originalList, half);
+            }
+
+            // Ensure the list was modified in place if an in-place version was used.  Again, note that the list being
+            // modified is not _technically_ enforced by the algorithm for an in-place shuffle, but is guaranteed to
+            // happen with the seed we chose for this test, and ensures that the implementation is shuffling in-place.
+            if (inPlace)
+                Assert.NotEqual(originalList, currentList);
+            else
+                Assert.Equal(originalList, currentList);
         }
     }
 }

--- a/ShaiRandom/GapShuffler.cs
+++ b/ShaiRandom/GapShuffler.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using ShaiRandom.Generators;
+
+namespace ShaiRandom
+{
+    public struct GapShufflerEnumerator<TItem> : IEnumerator<TItem>, IEnumerable<TItem>
+    {
+        private readonly IList<TItem> _items;
+        private readonly IEnhancedRandom _rng;
+        private int _index;
+
+        // Suppress warning stating to use auto-property because we want to guarantee micro-performance
+        // characteristics.
+#pragma warning disable IDE0032 // Use auto property
+        private TItem _current;
+#pragma warning restore IDE0032 // Use auto property
+
+        /// <summary>
+        /// The current value for enumeration.
+        /// </summary>
+        public TItem Current => _current;
+
+        object? IEnumerator.Current => _current;
+
+        public GapShufflerEnumerator(IEnhancedRandom rng, IEnumerable<TItem> items)
+        {
+            _items = items.ToArray();
+            _rng = rng;
+
+            rng.Shuffle(_items);
+
+            _index = 0;
+            _current = default!;
+        }
+
+        /// <summary>
+        /// Creates an enumerator that implements the "gap shuffle" algorithm.  Instead of copying the list like the
+        /// other constructor or the IList.GapShuffler extension method, this takes a reference to the list and uses it
+        /// without making a copy.
+        ///
+        /// This means that the list you give it will change pseudo-randomly as you advance the enumerator.  This is
+        /// useful if you do not care about the order of the collection after you are done with the enumerator and wish
+        /// to avoid a copy being made.
+        /// </summary>
+        /// <param name="rng">The RNG to use.</param>
+        /// <param name="items">The list of items to shuffle.</param>
+        public GapShufflerEnumerator(IEnhancedRandom rng, ref IList<TItem> items)
+        {
+            _items = items;
+            _rng = rng;
+
+            rng.Shuffle(_items);
+
+            _index = 0;
+            _current = default!;
+        }
+
+        public bool MoveNext()
+        {
+            int size = _items.Count; // In case size changes while we're iterating
+            if(size == 1)
+            {
+                _current = _items[0];
+                return true;
+            }
+            if(_index >= size)
+            {
+                int n = size - 1;
+                int swapWith;
+                for (int i = n; i > 1; i--) {
+                    swapWith = _rng.NextInt(i);
+                    (_items[i - 1], _items[swapWith]) = (_items[swapWith], _items[i - 1]);
+                }
+                swapWith = 1 + _rng.NextInt(n);
+                (_items[n], _items[swapWith]) = (_items[swapWith], _items[n]);
+                _index = 0;
+            }
+            _current = _items[_index++];
+            return true;
+        }
+
+        /// <summary>
+        /// Returns this enumerator.
+        /// </summary>
+        /// <returns>This enumerator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public GapShufflerEnumerator<TItem> GetEnumerator() => this;
+
+        // Explicitly implemented to ensure we prefer the non-boxing versions where possible
+        #region Explicit Interface Implementations
+        /// <summary>
+        /// This iterator does not support resetting.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        void IEnumerator.Reset() => throw new NotSupportedException();
+        IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+
+        void IDisposable.Dispose()
+        { }
+        #endregion
+    }
+}

--- a/ShaiRandom/GapShuffler.cs
+++ b/ShaiRandom/GapShuffler.cs
@@ -143,6 +143,16 @@ namespace ShaiRandom
         }
 
         /// <summary>
+        /// Returns the next item in the sequence.
+        /// </summary>
+        /// <returns>The next (shuffled) item in the sequence.</returns>
+        public TItem Next()
+        {
+            MoveNext();
+            return _current;
+        }
+
+        /// <summary>
         /// Returns this enumerator.
         /// </summary>
         /// <returns>This enumerator.</returns>
@@ -257,6 +267,16 @@ namespace ShaiRandom
             }
             _current = span[_index++];
             return true;
+        }
+
+        /// <summary>
+        /// Returns the next item in the sequence.
+        /// </summary>
+        /// <returns>The next (shuffled) item in the sequence.</returns>
+        public TItem Next()
+        {
+            MoveNext();
+            return _current;
         }
 
         /// <summary>

--- a/ShaiRandom/GapShuffler.cs
+++ b/ShaiRandom/GapShuffler.cs
@@ -13,8 +13,8 @@ namespace ShaiRandom
     /// quick succession.
     ///
     /// Generally, you should use <see cref="EnhancedRandomExtensions.GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>
-    /// or <see cref="EnhancedRandomExtensions.GapShuffleInPlace{TItem}"/>to get an instance of this, rather than creating
-    /// one yourself.
+    /// or <see cref="EnhancedRandomExtensions.GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>
+    /// to get an instance of this, rather than creating one yourself.
     /// </summary>
     /// <remarks>
     /// This enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
@@ -148,6 +148,123 @@ namespace ShaiRandom
         /// <returns>This enumerator.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public GapShufflerEnumerator<TItem> GetEnumerator() => this;
+
+        // Explicitly implemented to ensure we prefer the non-boxing versions where possible
+        #region Explicit Interface Implementations
+        /// <summary>
+        /// This iterator does not support resetting.
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        void IEnumerator.Reset() => throw new NotSupportedException();
+        IEnumerator<TItem> IEnumerable<TItem>.GetEnumerator() => this;
+        IEnumerator IEnumerable.GetEnumerator() => this;
+
+        void IDisposable.Dispose()
+        { }
+        #endregion
+    }
+
+    /// <summary>
+    /// A custom enumerator used to efficiently implement an infinite "gap shuffle"; a shuffle which takes a fixed-size
+    /// set of items and produce a shuffled stream of them such that an element is never chosen in
+    /// quick succession.
+    ///
+    /// Generally, you should use <see cref="EnhancedRandomExtensions.GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,ReadOnlyMemory{TItem})"/>
+    /// or <see cref="EnhancedRandomExtensions.GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>to get an instance of this, rather than creating
+    /// one yourself.
+    /// </summary>
+    /// <remarks>
+    /// This enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
+    /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
+    /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
+    /// of the items. These shuffles are spaced so that a single element should always have a large amount of "gap" in
+    /// order between one appearance and the next. Specifically, all elements must be returned precisely once before
+    /// elements are allowed to repeat.
+    ///
+    /// The Memory object is provided in the constructor, and it will store this object internally and repeatedly shuffle
+    /// it as the iterator progresses.it will copy elements into an
+    /// array, as well a a similar constructor which copies a Span.  Like most enumerators, modifying the collection
+    /// while the shuffle is active (including adding or removing items) will cause undefined behavior.
+    ///
+    /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
+    /// IEnumerable&lt;TItem&gt; by using "yield return".  This type does implement <see cref="IEnumerable{TItem}"/>,
+    /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
+    /// performance due to boxing of the iterator.
+    /// </remarks>
+    public struct GapShufflerInPlaceMemoryEnumerator<TItem> : IEnumerator<TItem>, IEnumerable<TItem>
+    {
+        private readonly Memory<TItem> _items;
+        private readonly IEnhancedRandom _rng;
+        private int _index;
+
+        // We store the size instead of using _items.Count in MoveNext because changing the items in the middle of
+        // an enumeration is not useful behavior in either case, and this is faster for many collections.
+        private readonly int _size;
+
+        // Suppress warning stating to use auto-property because we want to guarantee micro-performance
+        // characteristics.
+#pragma warning disable IDE0032 // Use auto property
+        private TItem _current;
+#pragma warning restore IDE0032 // Use auto property
+
+        /// <summary>
+        /// The current value for enumeration.
+        /// </summary>
+        public TItem Current => _current;
+
+        /// <inheritdoc />
+        object? IEnumerator.Current => _current;
+
+        /// <summary>
+        /// Creates an enumerator that implements the "gap shuffle" algorithm.  The Memory&lt;TItem&gt; it receives
+        /// is stored directly and will be shuffled in-place repeatedly as the iterator advances.
+        /// </summary>
+        /// <param name="rng">The RNG to use.</param>
+        /// <param name="items">The list of items to shuffle; the items will be shuffled in place, and no copy of this list is made.</param>
+        public GapShufflerInPlaceMemoryEnumerator(IEnhancedRandom rng, Memory<TItem> items)
+        {
+            _items = items;
+            _size = _items.Length;
+            _rng = rng;
+
+            rng.Shuffle(_items.Span);
+
+            _index = 0;
+            _current = default!;
+        }
+
+        /// <inheritdoc />
+        public bool MoveNext()
+        {
+            var span = _items.Span;
+
+            if(_size == 1)
+            {
+                _current = span[0];
+                return true;
+            }
+            if(_index >= _size)
+            {
+                int n = _size - 1;
+                int swapWith;
+                for (int i = n; i > 1; i--) {
+                    swapWith = _rng.NextInt(i);
+                    (span[i - 1], span[swapWith]) = (span[swapWith], span[i - 1]);
+                }
+                swapWith = 1 + _rng.NextInt(n);
+                (span[n], span[swapWith]) = (span[swapWith], span[n]);
+                _index = 0;
+            }
+            _current = span[_index++];
+            return true;
+        }
+
+        /// <summary>
+        /// Returns this enumerator.
+        /// </summary>
+        /// <returns>This enumerator.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public GapShufflerInPlaceMemoryEnumerator<TItem> GetEnumerator() => this;
 
         // Explicitly implemented to ensure we prefer the non-boxing versions where possible
         #region Explicit Interface Implementations

--- a/ShaiRandom/GapShuffler.cs
+++ b/ShaiRandom/GapShuffler.cs
@@ -17,23 +17,32 @@ namespace ShaiRandom
     /// (or one of their overloads) to get an instance of this, rather than creating one yourself.
     /// </summary>
     /// <remarks>
-    /// This enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-    /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-    /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-    /// of the items. These shuffles are spaced so that a single element should always have a large amount of "gap" in
-    /// order between one appearance and the next. Specifically, all elements must be returned precisely once before
-    /// elements are allowed to repeat.
+    /// The "gap shuffle" algorithm this enumerator implements, is akin to an infinite-length IEnumerable that shuffles
+    /// a sequence, iterates over the shuffled elements as they are requested, and when it runs out of elements it
+    /// shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently returned item in the
+    /// sequence from being returned again immediately after the items are shuffled.
     ///
-    /// It supports in-place enumeration, where you give it a list and it performs its shuffles in place on the list or array
+    /// One use case for the GapShuffle implementation is for text generation, where using the same word in rapid
+    /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+    /// using the same colors for skin and for long hair will make a human look like they have tentacles on their head,
+    /// so you'd almost always want different colors for those two.
+    ///
+    /// This enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to iterate it
+    /// until its completion.  You can simply call the <see cref="Next"/> function a fixed number of times, or if
+    /// you need to use it in a loop, you will need to either ensure you call "break", or use LINQ's .Take(n) function,
+    /// in order to avoid an infinite loop.
+    ///
+    /// It supports in-place enumeration, where you give it a list and it performs its shuffles in place on the list
     /// you specify.  It also provides a constructor where you give it an IEnumerable, and it will copy elements into an
     /// array, as well a a similar constructor which copies a Span.  In the case of in-place enumeration, like most
-    /// enumerators, modifying the collection while the shuffle is active (including adding or removing items) will cause
-    /// undefined behavior.
+    /// enumerators, modifying the collection while the shuffle is active (including adding or removing items) is not
+    /// supported and is considered undefined behavior.
     ///
-    /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;TItem&gt; by using "yield return".  This type does implement <see cref="IEnumerable{TItem}"/>,
-    /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
-    /// performance due to boxing of the iterator.
+    /// This type is a struct which implements the enumerator paradigm, so it can be used directly in a foreach loop;
+    /// and when you do so, it's much more efficient than a function returning IEnumerable&lt;TItem&gt; by using
+    /// "yield return".  This type does also implement <see cref="IEnumerable{TItem}"/>, so you can pass it to functions
+    /// which require one (for example, System.LINQ).  However, this will have reduced performance due to boxing of the
+    /// iterator.
     /// </remarks>
     public struct GapShufflerEnumerator<TItem> : IEnumerator<TItem>, IEnumerable<TItem>
     {
@@ -184,22 +193,30 @@ namespace ShaiRandom
     /// one yourself.
     /// </summary>
     /// <remarks>
-    /// This enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-    /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-    /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-    /// of the items. These shuffles are spaced so that a single element should always have a large amount of "gap" in
-    /// order between one appearance and the next. Specifically, all elements must be returned precisely once before
-    /// elements are allowed to repeat.
+    /// The "gap shuffle" algorithm this enumerator implements, is akin to an infinite-length IEnumerable that shuffles
+    /// a sequence, iterates over the shuffled elements as they are requested, and when it runs out of elements it
+    /// shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently returned item in the
+    /// sequence from being returned again immediately after the items are shuffled.
     ///
-    /// The Memory object is provided in the constructor, and it will store this object internally and repeatedly shuffle
-    /// it as the iterator progresses.it will copy elements into an
-    /// array, as well a a similar constructor which copies a Span.  Like most enumerators, modifying the collection
-    /// while the shuffle is active (including adding or removing items) will cause undefined behavior.
+    /// One use case for the GapShuffle implementation is for text generation, where using the same word in rapid
+    /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+    /// using the same colors for skin and for long hair will make a human look like they have tentacles on their head,
+    /// so you'd almost always want different colors for those two.
     ///
-    /// This type is a struct, and as such is much more efficient when used in a foreach loop than a function returning
-    /// IEnumerable&lt;TItem&gt; by using "yield return".  This type does implement <see cref="IEnumerable{TItem}"/>,
-    /// so you can pass it to functions which require one (for example, System.LINQ).  However, this will have reduced
-    /// performance due to boxing of the iterator.
+    /// This enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to iterate it
+    /// until its completion.  You can simply call the <see cref="Next"/> function a fixed number of times, or if
+    /// you need to use it in a loop, you will need to either ensure you call "break", or use LINQ's .Take(n) function,
+    /// in order to avoid an infinite loop.
+    ///
+    /// The Memory object given in the constructor is stored internally, and will be shuffled in-place as needed
+    /// as the enumerator advances.Like most in-place enumerators, modifying the collection while the shuffle is active
+    /// (including adding or removing items) is not supported and is considered undefined behavior.
+    ///
+    /// This type is a struct which implements the enumerator paradigm, so it can be used directly in a foreach loop;
+    /// and when you do so, it's much more efficient than a function returning IEnumerable&lt;TItem&gt; by using
+    /// "yield return".  This type does also implement <see cref="IEnumerable{TItem}"/>, so you can pass it to functions
+    /// which require one (for example, System.LINQ).  However, this will have reduced performance due to boxing of the
+    /// iterator.
     /// </remarks>
     public struct GapShufflerInPlaceMemoryEnumerator<TItem> : IEnumerator<TItem>, IEnumerable<TItem>
     {

--- a/ShaiRandom/GapShuffler.cs
+++ b/ShaiRandom/GapShuffler.cs
@@ -12,9 +12,9 @@ namespace ShaiRandom
     /// set of items and produce a shuffled stream of them such that an element is never chosen in
     /// quick succession.
     ///
-    /// Generally, you should use <see cref="EnhancedRandomExtensions.GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>
-    /// or <see cref="EnhancedRandomExtensions.GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>
-    /// to get an instance of this, rather than creating one yourself.
+    /// Generally, you should use <see cref="EnhancedRandomExtensions.GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>
+    /// or <see cref="EnhancedRandomExtensions.InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>
+    /// (or one of their overloads) to get an instance of this, rather than creating one yourself.
     /// </summary>
     /// <remarks>
     /// This enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
@@ -179,8 +179,8 @@ namespace ShaiRandom
     /// set of items and produce a shuffled stream of them such that an element is never chosen in
     /// quick succession.
     ///
-    /// Generally, you should use <see cref="EnhancedRandomExtensions.GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,ReadOnlyMemory{TItem})"/>
-    /// or <see cref="EnhancedRandomExtensions.GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>to get an instance of this, rather than creating
+    /// Generally, you should use <see cref="EnhancedRandomExtensions.GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.ReadOnlyMemory{TItem})"/>
+    /// or <see cref="EnhancedRandomExtensions.InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>to get an instance of this, rather than creating
     /// one yourself.
     /// </summary>
     /// <remarks>

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -691,7 +691,7 @@ namespace ShaiRandom.Generators
         /// elements are allowed to repeat.
         ///
         /// The elements in the IEnumerable specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>.
+        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>.
         ///
         /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
         /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
@@ -700,7 +700,7 @@ namespace ShaiRandom.Generators
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, IEnumerable<TItem> items)
+        public static GapShufflerEnumerator<TItem> GapShuffler<TItem>(this IEnhancedRandom rng, IEnumerable<TItem> items)
             => new GapShufflerEnumerator<TItem>(rng, items);
 
         /// <summary>
@@ -717,7 +717,7 @@ namespace ShaiRandom.Generators
         ///
         /// The elements in the span specified are copied internally into an array; if you need to avoid a copy,
         /// you can instead use one of the overloads of
-        /// <see cref="GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>;
+        /// <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>;
         /// however you'll need a Memory or IList object instead.
         ///
         /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
@@ -727,7 +727,7 @@ namespace ShaiRandom.Generators
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, ReadOnlySpan<TItem> items)
+        public static GapShufflerEnumerator<TItem> GapShuffler<TItem>(this IEnhancedRandom rng, ReadOnlySpan<TItem> items)
             => new GapShufflerEnumerator<TItem>(rng, items);
 
         /// <summary>
@@ -744,7 +744,7 @@ namespace ShaiRandom.Generators
         /// elements are allowed to repeat.
         ///
         /// The list specified is stored internally by the iterator; no copy of the list is made.  If you want to instead
-        /// make a copy, you can use one of the overloads of <see cref="GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>.
+        /// make a copy, you can use one of the overloads of <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>.
         /// Note that the order of elements in the list you give will be randomized as the iterator advances, and you should
         /// not make any changes to the list while the iterator is active.
         ///
@@ -755,7 +755,7 @@ namespace ShaiRandom.Generators
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, IList<TItem> items)
+        public static GapShufflerEnumerator<TItem> InPlaceGapShuffler<TItem>(this IEnhancedRandom rng, IList<TItem> items)
             => new GapShufflerEnumerator<TItem>(rng, ref items);
 
         /// <summary>
@@ -771,7 +771,7 @@ namespace ShaiRandom.Generators
         /// elements are allowed to repeat.
         ///
         /// The elements in the Memory object specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>; but this wont' work with spans.
+        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>; but this wont' work with spans.
         ///
         /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
         /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
@@ -780,7 +780,7 @@ namespace ShaiRandom.Generators
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, ReadOnlyMemory<TItem> items)
+        public static GapShufflerEnumerator<TItem> GapShuffler<TItem>(this IEnhancedRandom rng, ReadOnlyMemory<TItem> items)
             => new GapShufflerEnumerator<TItem>(rng, items.Span);
 
         /// <summary>
@@ -797,7 +797,7 @@ namespace ShaiRandom.Generators
         /// elements are allowed to repeat.
         ///
         /// The list specified is stored internally by the iterator; no copy of the list is made.  If you want to instead
-        /// make a copy, you can use <see cref="GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.ReadOnlyMemory{TItem})"/>.
+        /// make a copy, you can use <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.ReadOnlyMemory{TItem})"/>.
         /// Note that the order of elements in the list you give will be randomized as the iterator advances, and you should
         /// not make any changes to the list while the iterator is active.
         ///
@@ -808,7 +808,7 @@ namespace ShaiRandom.Generators
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerInPlaceMemoryEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, Memory<TItem> items)
+        public static GapShufflerInPlaceMemoryEnumerator<TItem> InPlaceGapShuffler<TItem>(this IEnhancedRandom rng, Memory<TItem> items)
             => new GapShufflerInPlaceMemoryEnumerator<TItem>(rng, items);
 
         /// <summary>

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -679,23 +679,34 @@ namespace ShaiRandom.Generators
         }
 
         /// <summary>
-        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
-        /// stream of them such that an element is never chosen in quick succession.
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an
+        /// infinite shuffled stream of them such that an element is never chosen in quick succession.
         /// </summary>
         /// <remarks>
-        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
-        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
-        /// elements are allowed to repeat.
+        /// The "gap shuffle" algorithm the returned enumerator implements, is akin to an infinite-length IEnumerable
+        /// that shuffles a sequence, iterates over the shuffled elements as they are requested, and when it runs out of
+        /// elements it shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently
+        /// returned item in the sequence from being returned again immediately after the items are shuffled.
+        ///
+        /// One use case for the gap-shuffle algorithm is for text generation, where using the same word in rapid
+        /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+        /// using the same colors for skin and for long hair will make a human look like they have tentacles on their
+        /// head, so you'd almost always want different colors for those two.
+        ///
+        /// The returned enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to
+        /// iterate it until its completion.  You can simply call the <see cref="GapShufflerEnumerator{TItem}.Next"/>
+        /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
+        /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
         ///
         /// The elements in the IEnumerable specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>.
+        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>
+        /// or one of its overloads.
         ///
-        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
-        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
+        /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
+        /// IEnumerable when used this way).  If you need an IEnumerable to use with LINQ or other code, the returned struct
+        /// also implements IEnumerable; however note that iterating over it this way will not perform as well as
+        /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
@@ -704,25 +715,34 @@ namespace ShaiRandom.Generators
             => new GapShufflerEnumerator<TItem>(rng, items);
 
         /// <summary>
-        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
-        /// stream of them such that an element is never chosen in quick succession.
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an
+        /// infinite shuffled stream of them such that an element is never chosen in quick succession.
         /// </summary>
         /// <remarks>
-        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
-        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
-        /// elements are allowed to repeat.
+        /// The "gap shuffle" algorithm the returned enumerator implements, is akin to an infinite-length IEnumerable
+        /// that shuffles a sequence, iterates over the shuffled elements as they are requested, and when it runs out of
+        /// elements it shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently
+        /// returned item in the sequence from being returned again immediately after the items are shuffled.
         ///
-        /// The elements in the span specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use one of the overloads of
-        /// <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>;
-        /// however you'll need a Memory or IList object instead.
+        /// One use case for the gap-shuffle algorithm is for text generation, where using the same word in rapid
+        /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+        /// using the same colors for skin and for long hair will make a human look like they have tentacles on their
+        /// head, so you'd almost always want different colors for those two.
         ///
-        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
-        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// The returned enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to
+        /// iterate it until its completion.  You can simply call the <see cref="GapShufflerEnumerator{TItem}.Next"/>
+        /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
+        /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
+        ///
+        /// The elements in the Span specified are copied internally into an array; if you need to avoid a copy,
+        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>
+        /// or one of its overloads; however you'll need a Memory&lt;T&gt; object or some other non-ref struct.
+        ///
+        /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
+        /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
+        /// IEnumerable when used this way).  If you need an IEnumerable to use with LINQ or other code, the returned struct
+        /// also implements IEnumerable; however note that iterating over it this way will not perform as well as
+        /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
@@ -731,26 +751,36 @@ namespace ShaiRandom.Generators
             => new GapShufflerEnumerator<TItem>(rng, items);
 
         /// <summary>
-        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
-        /// stream of them such that an element is never chosen in quick succession.  The given list is used directly,
-        /// so its order will be randomized as the iterator advances.
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an
+        /// infinite shuffled stream of them such that an element is never chosen in quick succession.
         /// </summary>
         /// <remarks>
-        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
-        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
-        /// elements are allowed to repeat.
+        /// The "gap shuffle" algorithm the returned enumerator implements, is akin to an infinite-length IEnumerable
+        /// that shuffles a sequence, iterates over the shuffled elements as they are requested, and when it runs out of
+        /// elements it shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently
+        /// returned item in the sequence from being returned again immediately after the items are shuffled.
         ///
-        /// The list specified is stored internally by the iterator; no copy of the list is made.  If you want to instead
-        /// make a copy, you can use one of the overloads of <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>.
-        /// Note that the order of elements in the list you give will be randomized as the iterator advances, and you should
-        /// not make any changes to the list while the iterator is active.
+        /// One use case for the gap-shuffle algorithm is for text generation, where using the same word in rapid
+        /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+        /// using the same colors for skin and for long hair will make a human look like they have tentacles on their
+        /// head, so you'd almost always want different colors for those two.
         ///
-        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
-        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// The returned enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to
+        /// iterate it until its completion.  You can simply call the <see cref="GapShufflerEnumerator{TItem}.Next"/>
+        /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
+        /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
+        ///
+        /// The given list is stored directly in the enumerator, so elements will be shuffled in-place as needed as the
+        /// enumerator is advanced.  Therefore, you should not make any changes to the list while the enumerator is active.
+        /// If you want to instead make a copy, you can use one of the overloads of
+        /// <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>
+        /// instead.
+        ///
+        /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
+        /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
+        /// IEnumerable when used this way).  If you need an IEnumerable to use with LINQ or other code, the returned struct
+        /// also implements IEnumerable; however note that iterating over it this way will not perform as well as
+        /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
@@ -759,23 +789,34 @@ namespace ShaiRandom.Generators
             => new GapShufflerEnumerator<TItem>(rng, ref items);
 
         /// <summary>
-        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
-        /// stream of them such that an element is never chosen in quick succession.
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an
+        /// infinite shuffled stream of them such that an element is never chosen in quick succession.
         /// </summary>
         /// <remarks>
-        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
-        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
-        /// elements are allowed to repeat.
+        /// The "gap shuffle" algorithm the returned enumerator implements, is akin to an infinite-length IEnumerable
+        /// that shuffles a sequence, iterates over the shuffled elements as they are requested, and when it runs out of
+        /// elements it shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently
+        /// returned item in the sequence from being returned again immediately after the items are shuffled.
+        ///
+        /// One use case for the gap-shuffle algorithm is for text generation, where using the same word in rapid
+        /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+        /// using the same colors for skin and for long hair will make a human look like they have tentacles on their
+        /// head, so you'd almost always want different colors for those two.
+        ///
+        /// The returned enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to
+        /// iterate it until its completion.  You can simply call the <see cref="GapShufflerEnumerator{TItem}.Next"/>
+        /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
+        /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
         ///
         /// The elements in the Memory object specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>; but this wont' work with spans.
+        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>
+        /// or one of its overloads instead.
         ///
-        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
-        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
+        /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
+        /// IEnumerable when used this way).  If you need an IEnumerable to use with LINQ or other code, the returned struct
+        /// also implements IEnumerable; however note that iterating over it this way will not perform as well as
+        /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
@@ -784,26 +825,36 @@ namespace ShaiRandom.Generators
             => new GapShufflerEnumerator<TItem>(rng, items.Span);
 
         /// <summary>
-        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
-        /// stream of them such that an element is never chosen in quick succession.  The given list is used directly,
-        /// so its order will be randomized as the iterator advances.
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an
+        /// infinite shuffled stream of them such that an element is never chosen in quick succession.
         /// </summary>
         /// <remarks>
-        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
-        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
-        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
-        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
-        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
-        /// elements are allowed to repeat.
+        /// The "gap shuffle" algorithm the returned enumerator implements, is akin to an infinite-length IEnumerable
+        /// that shuffles a sequence, iterates over the shuffled elements as they are requested, and when it runs out of
+        /// elements it shuffles the sequence again. The Gap in the name refers to how it prevents the most-recently
+        /// returned item in the sequence from being returned again immediately after the items are shuffled.
         ///
-        /// The list specified is stored internally by the iterator; no copy of the list is made.  If you want to instead
-        /// make a copy, you can use <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.ReadOnlyMemory{TItem})"/>.
-        /// Note that the order of elements in the list you give will be randomized as the iterator advances, and you should
-        /// not make any changes to the list while the iterator is active.
+        /// One use case for the gap-shuffle algorithm is for text generation, where using the same word in rapid
+        /// succession makes the writing look less "educated." It can also be useful for color selection; in pixel art,
+        /// using the same colors for skin and for long hair will make a human look like they have tentacles on their
+        /// head, so you'd almost always want different colors for those two.
         ///
-        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
-        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
-        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// The returned enumerator is infinite (but lazily evaluated), so you will need to ensure you do not attempt to
+        /// iterate it until its completion.  You can simply call the <see cref="GapShufflerInPlaceMemoryEnumerator{TItem}.Next"/>
+        /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
+        /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
+        ///
+        /// The given Memory object is stored directly in the enumerator, so elements will be shuffled in-place as needed as the
+        /// enumerator is advanced.  Therefore, you should not make any changes to the memory while the enumerator is active.
+        /// If you want to instead make a copy, you can use
+        /// <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.ReadOnlyMemory{TItem})"/> or one of
+        /// its overloads instead.
+        ///
+        /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
+        /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
+        /// IEnumerable when used this way).  If you need an IEnumerable to use with LINQ or other code, the returned struct
+        /// also implements IEnumerable; however note that iterating over it this way will not perform as well as
+        /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
         /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -678,6 +678,12 @@ namespace ShaiRandom.Generators
             }
         }
 
+        public static GapShufflerEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, IList<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, ref items);
+
+        public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, IEnumerable<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, items);
+
         /// <summary>
         /// Gets a normally-distributed (Gaussian) double, with a the specified mean (default 0.0) and standard deviation (default 1.0).
         /// If the standard deviation is 1.0 and the mean is 0.0, then this can produce results between -8.209536145151493 and 8.209536145151493 (both extremely rarely).

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -770,11 +770,9 @@ namespace ShaiRandom.Generators
         /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
         /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
         ///
-        /// The given list is stored directly in the enumerator, so elements will be shuffled in-place as needed as the
-        /// enumerator is advanced.  Therefore, you should not make any changes to the list while the enumerator is active.
-        /// If you want to instead make a copy, you can use one of the overloads of
-        /// <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>
-        /// instead.
+        /// The elements in the Memory object specified are copied internally into an array; if you need to avoid a copy,
+        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>
+        /// or one of its overloads instead.
         ///
         /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
         /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
@@ -783,10 +781,10 @@ namespace ShaiRandom.Generators
         /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
-        /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
+        /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerEnumerator<TItem> InPlaceGapShuffler<TItem>(this IEnhancedRandom rng, IList<TItem> items)
-            => new GapShufflerEnumerator<TItem>(rng, ref items);
+        public static GapShufflerEnumerator<TItem> GapShuffler<TItem>(this IEnhancedRandom rng, ReadOnlyMemory<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, items.Span);
 
         /// <summary>
         /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an
@@ -808,9 +806,11 @@ namespace ShaiRandom.Generators
         /// function a fixed number of times, or if you need to use it in a loop, you will need to either ensure you
         /// call "break", or use LINQ's .Take(n) function, in order to avoid an infinite loop.
         ///
-        /// The elements in the Memory object specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="InPlaceGapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>
-        /// or one of its overloads instead.
+        /// The given list is stored directly in the enumerator, so elements will be shuffled in-place as needed as the
+        /// enumerator is advanced.  Therefore, you should not make any changes to the list while the enumerator is active.
+        /// If you want to instead make a copy, you can use one of the overloads of
+        /// <see cref="GapShuffler{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>
+        /// instead.
         ///
         /// Many use cases may simply involve calling the Next function when you need to advance; but the returned struct
         /// is also a custom IEnumerator, so you can use it directly in a foreach loop (and it is faster than a typical
@@ -819,10 +819,10 @@ namespace ShaiRandom.Generators
         /// iterating directly over this object.
         /// </remarks>
         /// <param name="rng">RNG to use for shuffling.</param>
-        /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
+        /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
-        public static GapShufflerEnumerator<TItem> GapShuffler<TItem>(this IEnhancedRandom rng, ReadOnlyMemory<TItem> items)
-            => new GapShufflerEnumerator<TItem>(rng, items.Span);
+        public static GapShufflerEnumerator<TItem> InPlaceGapShuffler<TItem>(this IEnhancedRandom rng, IList<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, ref items);
 
         /// <summary>
         /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce an

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -678,11 +678,83 @@ namespace ShaiRandom.Generators
             }
         }
 
-        public static GapShufflerEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, IList<TItem> items)
-            => new GapShufflerEnumerator<TItem>(rng, ref items);
-
+        /// <summary>
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
+        /// stream of them such that an element is never chosen in quick succession.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
+        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
+        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
+        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
+        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
+        /// elements are allowed to repeat.
+        ///
+        /// The elements in the IEnumerable specified are copied internally into an array; if you need to avoid a copy,
+        /// you can instead use <see cref="GapShuffleInPlace{TItem}"/>.
+        ///
+        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// </remarks>
+        /// <param name="rng">RNG to use for shuffling.</param>
+        /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
+        /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
         public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, IEnumerable<TItem> items)
             => new GapShufflerEnumerator<TItem>(rng, items);
+
+        /// <summary>
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
+        /// stream of them such that an element is never chosen in quick succession.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
+        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
+        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
+        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
+        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
+        /// elements are allowed to repeat.
+        ///
+        /// The elements in the span specified are copied internally into an array; if you need to avoid a copy,
+        /// you can instead use <see cref="GapShuffleInPlace{TItem}"/>; but this wont' work with spans.
+        ///
+        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// </remarks>
+        /// <param name="rng">RNG to use for shuffling.</param>
+        /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
+        /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
+        public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, ReadOnlySpan<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, items);
+
+        /// <summary>
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
+        /// stream of them such that an element is never chosen in quick succession.  The given list is used directly,
+        /// so its order will be randomized as the iterator advances.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
+        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
+        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
+        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
+        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
+        /// elements are allowed to repeat.
+        ///
+        /// The list specified is stored internally by the iterator; no copy of the list is made.  If you want to instead
+        /// make a copy, you can use one of the overloads of <see cref="GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IEnumerable{TItem})"/>.
+        /// Note that the order of elements in the list you give will be randomized as the iterator advances, and you should
+        /// not make any changes to the list while the iterator is active.
+        ///
+        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// </remarks>
+        /// <param name="rng">RNG to use for shuffling.</param>
+        /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
+        /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
+        public static GapShufflerEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, IList<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, ref items);
 
         /// <summary>
         /// Gets a normally-distributed (Gaussian) double, with a the specified mean (default 0.0) and standard deviation (default 1.0).

--- a/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
+++ b/ShaiRandom/Generators/IEnhancedRandomExtensions.cs
@@ -691,7 +691,7 @@ namespace ShaiRandom.Generators
         /// elements are allowed to repeat.
         ///
         /// The elements in the IEnumerable specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="GapShuffleInPlace{TItem}"/>.
+        /// you can instead use <see cref="GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>.
         ///
         /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
         /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
@@ -716,7 +716,9 @@ namespace ShaiRandom.Generators
         /// elements are allowed to repeat.
         ///
         /// The elements in the span specified are copied internally into an array; if you need to avoid a copy,
-        /// you can instead use <see cref="GapShuffleInPlace{TItem}"/>; but this wont' work with spans.
+        /// you can instead use one of the overloads of
+        /// <see cref="GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Collections.Generic.IList{TItem})"/>;
+        /// however you'll need a Memory or IList object instead.
         ///
         /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
         /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
@@ -755,6 +757,59 @@ namespace ShaiRandom.Generators
         /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
         public static GapShufflerEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, IList<TItem> items)
             => new GapShufflerEnumerator<TItem>(rng, ref items);
+
+        /// <summary>
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
+        /// stream of them such that an element is never chosen in quick succession.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
+        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
+        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
+        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
+        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
+        /// elements are allowed to repeat.
+        ///
+        /// The elements in the Memory object specified are copied internally into an array; if you need to avoid a copy,
+        /// you can instead use <see cref="GapShuffleInPlace{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.Memory{TItem})"/>; but this wont' work with spans.
+        ///
+        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// </remarks>
+        /// <param name="rng">RNG to use for shuffling.</param>
+        /// <param name="items">Items to shuffle, which are copied into an array internally.</param>
+        /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
+        public static GapShufflerEnumerator<TItem> GapShuffle<TItem>(this IEnhancedRandom rng, ReadOnlyMemory<TItem> items)
+            => new GapShufflerEnumerator<TItem>(rng, items.Span);
+
+        /// <summary>
+        /// Implements an infinite "gap shuffle"; a shuffle which takes a fixed-size set of items and produce a shuffled
+        /// stream of them such that an element is never chosen in quick succession.  The given list is used directly,
+        /// so its order will be randomized as the iterator advances.
+        /// </summary>
+        /// <remarks>
+        /// The returned enumerator is infinite, so you will need to use it in a foreach loop and break out of it, use something
+        /// like LINQ's .Take(n) function, or use it in a while loop with a condition to break out of it in order to prevent
+        /// an infinite loop.  Until you break out of the loop, it will continue to produce a mostly random shuffled stream
+        /// of the items.  These shuffles are spaced so that a single element should always have a large amount of "gap" in
+        /// order between one appearance and the next.  Specifically, all elements must be returned precisely once before
+        /// elements are allowed to repeat.
+        ///
+        /// The list specified is stored internally by the iterator; no copy of the list is made.  If you want to instead
+        /// make a copy, you can use <see cref="GapShuffle{TItem}(ShaiRandom.Generators.IEnhancedRandom,System.ReadOnlyMemory{TItem})"/>.
+        /// Note that the order of elements in the list you give will be randomized as the iterator advances, and you should
+        /// not make any changes to the list while the iterator is active.
+        ///
+        /// The returned struct is a custom iterator which is very fast when used in a foreach loop.
+        /// If you need an IEnumerable to use with LINQ or other code, the returned struct does implement that interface;
+        /// however note that iterating over it this way will not perform as well as iterating directly over this object.
+        /// </remarks>
+        /// <param name="rng">RNG to use for shuffling.</param>
+        /// <param name="items">List of items to shuffle, which will be repeatedly shuffled in-place as the iterator advances.</param>
+        /// <returns>An infinite stream of (mostly) random shuffles of the given items, one item at a time.</returns>
+        public static GapShufflerInPlaceMemoryEnumerator<TItem> GapShuffleInPlace<TItem>(this IEnhancedRandom rng, Memory<TItem> items)
+            => new GapShufflerInPlaceMemoryEnumerator<TItem>(rng, items);
 
         /// <summary>
         /// Gets a normally-distributed (Gaussian) double, with a the specified mean (default 0.0) and standard deviation (default 1.0).


### PR DESCRIPTION
This PR implements a "gap-shuffle" algorithm heavily based on SquidSquad's GapShuffler.  It functions on IEnumerable, IList, Spans, and Memory representations of a list, and offers methods to shuffle an existing list in-place rather than copying its elements.

It uses a custom enumerator struct to ensure the implementation is as fast as reasonably possible when used in a foreach loop directly, and should still offer as reasonable as possible performance when used as an IEnumerable/with LINQ.

There are performance tests written, here are the most current results:

|                        Method | Size |        Mean |     Error |    StdDev |
|------------------------------ |----- |------------:|----------:|----------:|
|             ShaiRandomForeach |   10 |    181.4 ns |   0.64 ns |   0.50 ns |
|      ShaiRandomForeachInPlace |   10 |    153.1 ns |   0.64 ns |   0.57 ns |
|         ShaiRandomForeachTake |   10 |    329.7 ns |   2.50 ns |   2.21 ns |
|  ShaiRandomForeachInPlaceTake |   10 |    299.5 ns |   2.60 ns |   2.30 ns |
|            YieldReturnForeach |   10 |    253.7 ns |   2.61 ns |   2.44 ns |
|     YieldReturnForeachInPlace |   10 |    227.1 ns |   1.49 ns |   1.25 ns |
|        YieldReturnForeachTake |   10 |    339.6 ns |   1.76 ns |   1.56 ns |
| YieldReturnForeachInPlaceTake |   10 |    299.4 ns |   3.13 ns |   2.78 ns |
|                ShaiRandomLinq |   10 |    339.4 ns |   1.89 ns |   1.77 ns |
|         ShaiRandomLinqInPlace |   10 |    301.8 ns |   2.78 ns |   2.60 ns |
|               YieldReturnLinq |   10 |    325.4 ns |   1.05 ns |   0.82 ns |
|        YieldReturnLinqInPlace |   10 |    299.2 ns |   1.38 ns |   1.22 ns |
|         ShaiRandomIEnumerable |   10 |    227.8 ns |   1.15 ns |   0.96 ns |
|  ShaiRandomIEnumerableInPlace |   10 |    194.6 ns |   0.79 ns |   0.66 ns |
|             ShaiRandomForeach |   50 |    896.9 ns |   9.86 ns |   9.22 ns |
|      ShaiRandomForeachInPlace |   50 |    790.5 ns |   8.62 ns |   8.06 ns |
|         ShaiRandomForeachTake |   50 |  1,278.4 ns |   6.72 ns |   5.61 ns |
|  ShaiRandomForeachInPlaceTake |   50 |  1,238.2 ns |   5.49 ns |   4.87 ns |
|            YieldReturnForeach |   50 |  1,062.6 ns |   8.04 ns |   7.53 ns |
|     YieldReturnForeachInPlace |   50 |  1,067.0 ns |  11.19 ns |   9.92 ns |
|        YieldReturnForeachTake |   50 |  1,381.7 ns |   6.87 ns |   5.74 ns |
| YieldReturnForeachInPlaceTake |   50 |  1,284.3 ns |  10.25 ns |   9.09 ns |
|                ShaiRandomLinq |   50 |  1,312.6 ns |   4.44 ns |   4.15 ns |
|         ShaiRandomLinqInPlace |   50 |  1,234.7 ns |   3.99 ns |   3.54 ns |
|               YieldReturnLinq |   50 |  1,307.8 ns |   7.15 ns |   6.34 ns |
|        YieldReturnLinqInPlace |   50 |  1,258.1 ns |   7.36 ns |   6.88 ns |
|         ShaiRandomIEnumerable |   50 |    954.5 ns |   5.72 ns |   5.07 ns |
|  ShaiRandomIEnumerableInPlace |   50 |    901.9 ns |   6.17 ns |   5.47 ns |
|             ShaiRandomForeach |  100 |  1,771.8 ns |   7.08 ns |   6.62 ns |
|      ShaiRandomForeachInPlace |  100 |  1,580.3 ns |  12.28 ns |  10.25 ns |
|         ShaiRandomForeachTake |  100 |  2,449.0 ns |  26.14 ns |  24.45 ns |
|  ShaiRandomForeachInPlaceTake |  100 |  2,420.2 ns |  25.36 ns |  23.72 ns |
|            YieldReturnForeach |  100 |  2,100.5 ns |  24.74 ns |  23.15 ns |
|     YieldReturnForeachInPlace |  100 |  2,119.5 ns |  31.29 ns |  26.13 ns |
|        YieldReturnForeachTake |  100 |  2,568.7 ns |  18.23 ns |  16.16 ns |
| YieldReturnForeachInPlaceTake |  100 |  2,533.0 ns |  15.50 ns |  12.94 ns |
|                ShaiRandomLinq |  100 |  2,530.9 ns |  13.15 ns |  10.98 ns |
|         ShaiRandomLinqInPlace |  100 |  2,477.2 ns |  33.98 ns |  31.78 ns |
|               YieldReturnLinq |  100 |  2,593.8 ns |   8.45 ns |   6.60 ns |
|        YieldReturnLinqInPlace |  100 |  2,469.6 ns |   9.95 ns |   8.82 ns |
|         ShaiRandomIEnumerable |  100 |  1,938.1 ns |  33.57 ns |  28.03 ns |
|  ShaiRandomIEnumerableInPlace |  100 |  1,796.9 ns |  13.76 ns |  12.20 ns |
|             ShaiRandomForeach |  500 |  8,069.3 ns |  71.43 ns |  66.82 ns |
|      ShaiRandomForeachInPlace |  500 |  7,868.1 ns |  49.66 ns |  46.46 ns |
|         ShaiRandomForeachTake |  500 | 11,744.7 ns |  56.08 ns |  52.46 ns |
|  ShaiRandomForeachInPlaceTake |  500 | 12,007.3 ns |  34.62 ns |  30.69 ns |
|            YieldReturnForeach |  500 | 10,235.0 ns |  46.98 ns |  41.65 ns |
|     YieldReturnForeachInPlace |  500 | 10,582.6 ns |  66.67 ns |  55.67 ns |
|        YieldReturnForeachTake |  500 | 12,480.8 ns |  93.55 ns |  82.93 ns |
| YieldReturnForeachInPlaceTake |  500 | 12,606.0 ns |  62.80 ns |  58.74 ns |
|                ShaiRandomLinq |  500 | 12,512.6 ns | 106.35 ns |  94.28 ns |
|         ShaiRandomLinqInPlace |  500 | 12,044.0 ns | 107.10 ns |  94.94 ns |
|               YieldReturnLinq |  500 | 12,634.3 ns | 118.48 ns | 110.83 ns |
|        YieldReturnLinqInPlace |  500 | 12,170.7 ns |  74.08 ns |  69.29 ns |
|         ShaiRandomIEnumerable |  500 |  9,352.5 ns |  85.16 ns |  79.66 ns |
|  ShaiRandomIEnumerableInPlace |  500 |  8,787.7 ns |  48.35 ns |  45.22 ns |

Note that the custom enumerator seems to out-perform a more traditional "yield return" implementation considerably.  The use of System.LINQ does slow it down notably, but not much compared to the equivalent operations with `yield return`.